### PR TITLE
Remove output typo in master.sh

### DIFF
--- a/master.sh
+++ b/master.sh
@@ -12,4 +12,3 @@ systemctl start docker
 kubeadm init --token=${k8stoken}
 
 kubectl apply -f https://git.io/weave-kube
-daemonset "weave-net" created


### PR DESCRIPTION
`daemonset "weave-net" created` is obviously the output of the previous command and shouldn't be in the script.