### PR TITLE
Use criproxy to separate nodeless workloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .terraform/
 terraform.tfstate
 terraform.tfstate.backup
+env.tfvars

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .terraform/
-terraform.tfstate
-terraform.tfstate.backup
+*terraform.tfstate*
 env.tfvars
+kubeconfig

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-*.tfstate
-*.backup
+.terraform/
+terraform.tfstate
+terraform.tfstate.backup

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Simple Kubernetes Cluster with Milpa
+# Simple Nodeless Kubernetes Cluster with Milpa
 
 Note: this is based on [upmc-enterprises/kubeadm-aws](https://github.com/upmc-enterprises/kubeadm-aws).
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,80 @@
-## kubeadm quickstart on aws
+# Simple Kubernetes Cluster with Milpa
 
-This is a quickstart to get running with the new kubeadm tool which delivered in Kubernetes 1.4. Please see docs here for information about this new tool: http://kubernetes.io/docs/getting-started-guides/kubeadm/
+Note: this is based on [upmc-enterprises/kubeadm-aws](https://github.com/upmc-enterprises/kubeadm-aws).
 
-The goal of this project is to build out a simple cluster on AWS utilizing Terraform to build out infrastructure, then use kubeadm to bootstrap a Kubernetes cluster.
+This is a Terraform configuration for provisioning a simple (one master, one worker) nodeless Kubernetes cluster that uses [Milpa](https://www.elotl.co/kiyotdocs) as its container runtime.
 
-### How it works
+## Setup
 
-The terraform script builds out a new VPC in your account and 3 corresponding subnets. It will also provision an internet gateway and setup a routing table to allow internet access.
+Create a file at `~/env.tfvars`:
 
-#### _NOTE: This isn't ready for production!_
+    cluster-name = "my-cluster-name"
+    aws-access-key-id = "my-access-key"
+    aws-secret-access-key = "my-secret-key"
+    ssh-key-name = "my-ssh-key-on-EC2"
+    # Get your license at https://www.elotl.co/trial.
+    license-key = ""
+    license-id = ""
+    license-username = ""
+    license-password = ""
+    # Generate a token via:
+    # python -c 'import random; print "%0x.%0x" % (random.SystemRandom().getrandbits(3*8), random.SystemRandom().getrandbits(8*8))'
+    k8stoken = ""
 
-### Run it!
+Fill in all those variables, then apply the configuration:
 
-1. Clone the repo: `git clone https://github.com/upmc-enterprises/kubeadm-aws.git`
-- [Install Terraform](https://www.terraform.io/intro/getting-started/install.html)
-- Generate token: `python -c 'import random; print "%0x.%0x" % (random.SystemRandom().getrandbits(3*8), random.SystemRandom().getrandbits(8*8))'`
-- Generate ssh keys: `ssh-keygen -f k8s-test`
-- Run terraform plan: `terraform plan -var k8s-ssh-key="$(cat k8s-test.pub)" -var 'k8stoken=<token>'`
-- Build out infrastructure: `terraform apply -var k8s-ssh-key="$(cat k8s-test.pub)" -var 'k8stoken=<token>'`
-- ssh to kube master and run something: `ssh ubuntu@$(terraform output master_dns) -i k8s-test`
-- Done!
+    $ terraform init # Only needed the first time.
+    [...]
+    $ terraform apply -var-file ~/env.tfvars
+    [...]
+    Apply complete! Resources: 8 added, 0 changed, 0 destroyed.
+    
+    Outputs:
+    
+    master_ip = 3.81.184.107
+    worker_ip = 54.90.138.204
 
-### About
+This will create a cluster with one master and one worker.
 
-Built by UPMC Enterprises in Pittsburgh, PA. http://enterprises.upmc.com/
+SSH into the master node and check the status of the cluster:
+
+    ubuntu@ip-10-0-100-66:~$ kubectl cluster-info
+    Kubernetes master is running at https://10.0.100.66:6443
+    KubeDNS is running at https://10.0.100.66:6443/api/v1/namespaces/kube-system/services/kube-dns:dns/proxy
+    
+    To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.
+    ubuntu@ip-10-0-100-66:~$ kubectl get nodes
+    NAME              STATUS   ROLES    AGE   VERSION
+    ip-10-0-100-135   Ready    <none>   62s   v1.14.0
+    ip-10-0-100-66    Ready    master   97s   v1.14.0
+    ubuntu@ip-10-0-100-66:~$
+
+At this point, the cluster is ready to use. Pods will be scheduled to run in EC2 instances, instead of containers on the worker node.
+
+## Teardown
+
+Make sure all pods and services are removed. On the master:
+
+    ubuntu@ip-10-0-100-66:~$ for ns in $(kubectl get namespaces | tail -n+2 | awk '{print $1}'); do kubectl delete --all deployments --namespace=$ns; kubectl delete --all services --namespace=$ns; kubectl delete --all daemonsets --namespace=$ns; kubectl delete --all pods --namespace=$ns; done
+    No resources found
+    service "kubernetes" deleted
+    No resources found
+    No resources found
+    [...]
+    ubuntu@ip-10-0-100-66:~$
+
+Then you can log out from the master, and use Terraform to tear down the infrastructure:
+
+    $ terraform destroy -var-file ~/env.tfvars
+    [...]
+    Plan: 0 to add, 0 to change, 8 to destroy.
+    
+    Do you really want to destroy all resources?
+      Terraform will destroy all your managed infrastructure, as shown above.
+      There is no undo. Only 'yes' will be accepted to confirm.
+    
+      Enter a value: yes
+
+    [...]
+
+    Destroy complete! Resources: 8 destroyed.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,13 @@ SSH into the master node and check the status of the cluster:
     ip-10-0-100-66    Ready    master   97s   v1.14.0
     ubuntu@ip-10-0-100-66:~$
 
-At this point, the cluster is ready to use. Pods will be scheduled to run in EC2 instances, instead of containers on the worker node.
+At this point, the cluster is ready to use.
+
+To schedule pods via Milpa, you have to add an annotation:
+
+    ubuntu@ip-10-0-100-66:~$ kubectl run nginx --image=nginx --overrides='{"apiVersion": "apps/v1", "spec":{ "template":{ "metadata": { "annotations":{"kubernetes.io/target-runtime":"kiyot"} }, "spec": { "nodeSelector": {"kubernetes.io/role": "milpa-worker"} } } } }'
+
+If you have both Milpa and non-Milpa workers in your cluster, you will also have to add a `nodeSelector` as above, otherwise pods will also be scheduled to run on non-Milpa workers.
 
 ## Teardown
 

--- a/README.md
+++ b/README.md
@@ -8,20 +8,12 @@ This is a Terraform configuration for provisioning a simple (one master, one wor
 
 Create a file at `~/env.tfvars`:
 
-    cluster-name = "my-cluster-name"
-    aws-access-key-id = "my-access-key"
-    aws-secret-access-key = "my-secret-key"
-    ssh-key-name = "my-ssh-key-on-EC2"
-    # Get your license at https://www.elotl.co/trial.
-    license-key = ""
-    license-id = ""
-    license-username = ""
-    license-password = ""
-    # Generate a token via:
-    # python -c 'import random; print "%0x.%0x" % (random.SystemRandom().getrandbits(3*8), random.SystemRandom().getrandbits(8*8))'
-    k8stoken = ""
+```
+$ cp env-example.tfvars ~/env.tfvars
+$ vi ~/env.tfvars
+```
 
-Fill in all those variables, then apply the configuration:
+Fill in all the required variables, then apply the configuration:
 
     $ terraform init # Only needed the first time.
     [...]

--- a/cleanup-vpc.sh
+++ b/cleanup-vpc.sh
@@ -65,6 +65,14 @@ if [[ -n "$lbs" ]]; then
         aws elb delete-load-balancer --load-balancer-name $lb > /dev/null 2>&1
     done
 fi
+v2lbs=$(aws elbv2 describe-load-balancers | jq -r ".LoadBalancers | .[] | select(.VpcId==\"$VPC_ID\") | .LoadBalancerArn")
+if [[ -n "$v2lbs" ]]; then
+    echo "Removing v2 LBs:"
+    echo "$v2lbs"
+    for lb in $v2lbs; do
+        aws elbv2 delete-load-balancer --load-balancer-arn $lb > /dev/null 2>&1
+    done
+fi
 
 # Delete security groups in VPC.
 sgs=$(aws ec2 describe-security-groups | jq -r ".SecurityGroups | .[] | select(.VpcId == \"$VPC_ID\") | .GroupId")

--- a/cleanup-vpc.sh
+++ b/cleanup-vpc.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# Remove leftover Milpa cloud resources from an AWS VPC.
+#
+
+function usage() {
+    echo "Usage $0 <vpc-id> <milpa-cluster-name>"
+    echo "You can also set the environment variables VPC_ID and CLUSTER_NAME."
+    exit 1
+}
+
+function check_prg() {
+    $1 --version || {
+        echo "Can't find $prg."
+        exit 2
+    }
+}
+
+if [[ "$1" != "" ]]; then
+    VPC_ID="$1"
+fi
+if [[ -z "$VPC_ID" ]]; then
+    usage
+fi
+shift
+
+if [[ "$1" != "" ]]; then
+    CLUSTER_NAME="$1"
+fi
+if [[ -z "$CLUSTER_NAME" ]]; then
+    usage
+fi
+shift
+
+if [[ -n "$1" ]]; then
+    usage
+fi
+
+check_prg aws
+check_prg jq
+
+if [[ -n "$USE_AWS_ACCESS_KEY_ID" ]]; then
+    export AWS_ACCESS_KEY_ID="$USE_AWS_ACCESS_KEY_ID"
+fi
+
+if [[ -n "$USE_AWS_SECRET_ACCESS_KEY" ]]; then
+    export AWS_SECRET_ACCESS_KEY="$USE_AWS_SECRET_ACCESS_KEY"
+fi
+
+# Delete instances in VPC.
+while true; do
+    instances=$(aws ec2 describe-instances | jq -r ".Reservations | .[] | .Instances | .[] | select(.State.Name!=\"shutting-down\") | select(.State.Name!=\"terminated\") | select(.VpcId==\"$VPC_ID\") | select(.Tags) | select(.Tags[] | contains({\"Key\":\"MilpaClusterName\",\"Value\":\"$CLUSTER_NAME\"})) | .InstanceId")
+    if [[ "$instances" != "" ]]; then
+        echo "Terminating instances \"$instances\""
+        aws ec2 terminate-instances --instance-ids $instances
+    else
+        break
+    fi
+done
+
+# Delete LBs.
+while true; do
+    lbs=$(aws elb describe-load-balancers | jq -r ".LoadBalancerDescriptions | .[] | select(.VPCId==\"$VPC_ID\") | select(.Tags) | select(.Tags[] | contains({\"Key\":\"MilpaClusterName\",\"Value\":\"$CLUSTER_NAME\"})) | .LoadBalancerName")
+    if [[ "$lbs" != "" ]]; then
+        echo "Deleting LBs \"$lbs\""
+        for lb in $lbs; do
+            aws elb delete-load-balancer --load-balancer-name $lb
+        done
+    else
+        break
+    fi
+done
+
+# Delete security groups in VPC.
+for sg in $(aws ec2 describe-security-groups | jq -r ".SecurityGroups | .[] | select(.VpcId == \"$VPC_ID\") | select(.Tags) | select(.Tags[] | contains({\"Key\":\"MilpaClusterName\",\"Value\":\"$CLUSTER_NAME\"})) | .GroupId"); do
+    aws ec2 delete-security-group --group-id $sg
+done
+
+exit 0

--- a/cleanup-vpc.sh
+++ b/cleanup-vpc.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
 #
-# Remove leftover Milpa cloud resources from an AWS VPC.
+# Remove leftover cloud resources from an AWS VPC.
 #
 
 function usage() {
-    echo "Usage $0 <vpc-id> <milpa-cluster-name>"
-    echo "You can also set the environment variables VPC_ID and CLUSTER_NAME."
+    {
+        echo "Usage $0 <vpc-id> <milpa-cluster-name>"
+        echo "You can also set the environment variables VPC_ID and CLUSTER_NAME."
+    } >&2
     exit 1
 }
 
 function check_prg() {
     $1 --version || {
-        echo "Can't find $prg."
+        {
+            echo "Can't find $prg."
+        } >&2
         exit 2
     }
 }
@@ -39,41 +43,37 @@ fi
 check_prg aws
 check_prg jq
 
-if [[ -n "$USE_AWS_ACCESS_KEY_ID" ]]; then
-    export AWS_ACCESS_KEY_ID="$USE_AWS_ACCESS_KEY_ID"
-fi
-
-if [[ -n "$USE_AWS_SECRET_ACCESS_KEY" ]]; then
-    export AWS_SECRET_ACCESS_KEY="$USE_AWS_SECRET_ACCESS_KEY"
-fi
-
-# Delete instances in VPC.
+# Delete instances in VPC. Do this in a loop, since Milpa might be still
+# creating new instances.
 while true; do
     instances=$(aws ec2 describe-instances | jq -r ".Reservations | .[] | .Instances | .[] | select(.State.Name!=\"shutting-down\") | select(.State.Name!=\"terminated\") | select(.VpcId==\"$VPC_ID\") | select(.Tags) | select(.Tags[] | contains({\"Key\":\"MilpaClusterName\",\"Value\":\"$CLUSTER_NAME\"})) | .InstanceId")
-    if [[ "$instances" != "" ]]; then
-        echo "Terminating instances \"$instances\""
-        aws ec2 terminate-instances --instance-ids $instances
+    if [[ -n "$instances" ]]; then
+        echo "Terminating instances:"
+        echo "$instances"
+        aws ec2 terminate-instances --instance-ids $instances > /dev/null 2>&1
     else
         break
     fi
 done
 
 # Delete LBs.
-while true; do
-    lbs=$(aws elb describe-load-balancers | jq -r ".LoadBalancerDescriptions | .[] | select(.VPCId==\"$VPC_ID\") | select(.Tags) | select(.Tags[] | contains({\"Key\":\"MilpaClusterName\",\"Value\":\"$CLUSTER_NAME\"})) | .LoadBalancerName")
-    if [[ "$lbs" != "" ]]; then
-        echo "Deleting LBs \"$lbs\""
-        for lb in $lbs; do
-            aws elb delete-load-balancer --load-balancer-name $lb
-        done
-    else
-        break
-    fi
-done
+lbs=$(aws elb describe-load-balancers | jq -r ".LoadBalancerDescriptions | .[] | select(.VPCId==\"$VPC_ID\") | .LoadBalancerName")
+if [[ -n "$lbs" ]]; then
+    echo "Removing LBs:"
+    echo "$lbs"
+    for lb in $lbs; do
+        aws elb delete-load-balancer --load-balancer-name $lb > /dev/null 2>&1
+    done
+fi
 
 # Delete security groups in VPC.
-for sg in $(aws ec2 describe-security-groups | jq -r ".SecurityGroups | .[] | select(.VpcId == \"$VPC_ID\") | select(.Tags) | select(.Tags[] | contains({\"Key\":\"MilpaClusterName\",\"Value\":\"$CLUSTER_NAME\"})) | .GroupId"); do
-    aws ec2 delete-security-group --group-id $sg
-done
+sgs=$(aws ec2 describe-security-groups | jq -r ".SecurityGroups | .[] | select(.VpcId == \"$VPC_ID\") | .GroupId")
+if [[ -n "$sgs" ]]; then
+    echo "Removing SGs:"
+    echo "$sgs"
+    for sg in $sgs; do
+        aws ec2 delete-security-group --group-id $sg > /dev/null 2>&1
+    done
+fi
 
 exit 0

--- a/env-example.tfvars
+++ b/env-example.tfvars
@@ -1,0 +1,25 @@
+# The name of the cluster.
+cluster-name = "mycluster"
+# The access keys Milpa will use to create instances on AWS. Comment out or
+# leave empty to have Kubernetes and Milpa use IAM.
+#aws-access-key-id = ""
+#aws-secret-access-key = ""
+# The name of an already existing SSH key on EC2. This will be added to the
+# EC2 instances for SSH access. See
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html on how
+# to create or import one to EC2.
+ssh-key-name = "my-ssh-key"
+# License information for Milpa. Request a free license at
+# https://www.elotl.co/trial.
+license-key = "FILL_IN"
+license-id = "FILL_IN"
+license-username = "FILL_IN"
+license-password = "FILL_IN"
+# When you set up a new cluster, generate a token via:
+# python -c 'import random; print "%0x.%0x" % (random.SystemRandom().getrandbits(3*8), random.SystemRandom().getrandbits(8*8))'
+k8stoken = "e7ea06.8f558c9acdba2743"
+# Optional parameter. URL to fetch the installer from.
+#milpa-installer-url = ""
+# Optional parameters. URL and version of the Milpa node agent.
+#itzo-url = ""
+#itzo-version = ""

--- a/env-example.tfvars
+++ b/env-example.tfvars
@@ -20,3 +20,8 @@ license-password = "FILL_IN"
 # Optional parameters. URL and version of the Milpa node agent.
 #itzo-url = ""
 #itzo-version = ""
+# Specify the number of regular kubelet worker nodes.
+#workers = 0
+# Specify the number of Milpa worker nodes. Right now only 0 or 1 are
+# supported.
+#milpa-workers = 1

--- a/env-example.tfvars
+++ b/env-example.tfvars
@@ -15,9 +15,6 @@ license-key = "FILL_IN"
 license-id = "FILL_IN"
 license-username = "FILL_IN"
 license-password = "FILL_IN"
-# When you set up a new cluster, generate a token via:
-# python -c 'import random; print "%0x.%0x" % (random.SystemRandom().getrandbits(3*8), random.SystemRandom().getrandbits(8*8))'
-k8stoken = "e7ea06.8f558c9acdba2743"
 # Optional parameter. URL to fetch the installer from.
 #milpa-installer-url = ""
 # Optional parameters. URL and version of the Milpa node agent.

--- a/main.tf
+++ b/main.tf
@@ -400,6 +400,7 @@ data "template_file" "master-userdata" {
     k8stoken = "${data.external.k8stoken.result.token}"
     pod_cidr = "${var.pod-cidr}"
     service_cidr = "${var.service-cidr}"
+    non_masquerade_cidr = "${var.non-masquerade-cidr}"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -477,6 +477,7 @@ resource "aws_instance" "k8s-master" {
 resource "aws_instance" "k8s-milpa-worker" {
   ami           = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.medium"
+  count = "${var.milpa-workers}"
   subnet_id = "${aws_subnet.publicA.id}"
   user_data = "${data.template_file.milpa-worker-userdata.rendered}"
   key_name = "${var.ssh-key-name}"
@@ -492,6 +493,7 @@ resource "aws_instance" "k8s-milpa-worker" {
 resource "aws_instance" "k8s-worker" {
   ami           = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.medium"
+  count = "${var.workers}"
   subnet_id = "${aws_subnet.publicA.id}"
   user_data = "${data.template_file.worker-userdata.rendered}"
   key_name = "${var.ssh-key-name}"

--- a/main.tf
+++ b/main.tf
@@ -430,6 +430,7 @@ data "template_file" "worker-userdata" {
     k8stoken = "${data.external.k8stoken.result.token}"
     masterIP = "${aws_instance.k8s-master.private_ip}"
     pod_cidr = "${var.pod-cidr}"
+    non_masquerade_cidr = "${var.non-masquerade-cidr}"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -404,7 +404,7 @@ locals {
 data "template_file" "master-userdata" {
   template = "${file("${var.master-userdata}")}"
 
-  vars {
+  vars = {
     k8stoken = "${local.k8stoken}"
     pod_cidr = "${var.pod-cidr}"
     service_cidr = "${var.service-cidr}"
@@ -415,7 +415,7 @@ data "template_file" "master-userdata" {
 data "template_file" "milpa-worker-userdata" {
   template = "${file("${var.milpa-worker-userdata}")}"
 
-  vars {
+  vars = {
     k8stoken = "${local.k8stoken}"
     masterIP = "${aws_instance.k8s-master.private_ip}"
     service_cidr = "${var.service-cidr}"
@@ -436,7 +436,7 @@ data "template_file" "milpa-worker-userdata" {
 data "template_file" "worker-userdata" {
   template = "${file("${var.worker-userdata}")}"
 
-  vars {
+  vars = {
     k8stoken = "${local.k8stoken}"
     masterIP = "${aws_instance.k8s-master.private_ip}"
     pod_cidr = "${var.pod-cidr}"

--- a/main.tf
+++ b/main.tf
@@ -355,6 +355,9 @@ data "template_file" "worker-userdata" {
     license_id = "${var.license-id}"
     license_username = "${var.license-username}"
     license_password = "${var.license-password}"
+    itzo_url = "${var.itzo-url}"
+    itzo_version = "${var.itzo-version}"
+    milpa_installer_url = "${var.milpa-installer-url}"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -390,7 +390,7 @@ resource  "aws_iam_instance_profile" "k8s-worker" {
 }
 
 data "external" "k8stoken" {
-  program = ["python", "-c", "import random; print '{\"token\": \"%0x.%0x\"}' % (random.SystemRandom().getrandbits(3*8), random.SystemRandom().getrandbits(8*8))"]
+  program = ["python", "-c", "import random; print '{\"token\": \"%06x.%016x\"}' % (random.SystemRandom().getrandbits(3*8), random.SystemRandom().getrandbits(8*8))"]
 }
 
 data "template_file" "master-userdata" {

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,3 @@
-
 /*
 Copyright (c) 2016, UPMC Enterprises
 All rights reserved.
@@ -29,74 +28,74 @@ provider "aws" {
 }
 
 resource "aws_vpc" "main" {
-    cidr_block = "10.0.0.0/16"
-    enable_dns_hostnames = true
+  cidr_block = "10.0.0.0/16"
+  enable_dns_hostnames = true
 
-    tags {
-        Name = "TF_VPC"
-    }
+  tags {
+    Name = "TF_VPC"
+  }
 
-    provisioner "local-exec" {
-        # Remove any leftover instance, security group etc Milpa created. They
-        # would prevent terraform from destroying the VPC.
-        when    = "destroy"
-        command = "./cleanup-vpc.sh ${self.id} ${var.cluster-name}"
-        interpreter = ["/bin/bash", "-c"]
-        environment = {
-            AWS_ACCESS_KEY_ID = "${var.aws-access-key-id}"
-            AWS_SECRET_ACCESS_KEY = "${var.aws-secret-access-key}"
-        }
+  provisioner "local-exec" {
+    # Remove any leftover instance, security group etc Milpa created. They
+    # would prevent terraform from destroying the VPC.
+    when    = "destroy"
+    command = "./cleanup-vpc.sh ${self.id} ${var.cluster-name}"
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      AWS_ACCESS_KEY_ID = "${var.aws-access-key-id}"
+      AWS_SECRET_ACCESS_KEY = "${var.aws-secret-access-key}"
     }
+  }
 }
 
 resource "aws_internet_gateway" "gw" {
-    vpc_id = "${aws_vpc.main.id}"
+  vpc_id = "${aws_vpc.main.id}"
 
-    tags {
-        Name = "TF_main"
-    }
+  tags {
+    Name = "TF_main"
+  }
 
-    provisioner "local-exec" {
-        # Remove any leftover instance, security group etc Milpa created. They
-        # would prevent terraform from destroying the VPC.
-        when    = "destroy"
-        command = "./cleanup-vpc.sh ${self.vpc_id} ${var.cluster-name}"
-        interpreter = ["/bin/bash", "-c"]
-        environment = {
-            AWS_ACCESS_KEY_ID = "${var.aws-access-key-id}"
-            AWS_SECRET_ACCESS_KEY = "${var.aws-secret-access-key}"
-        }
+  provisioner "local-exec" {
+    # Remove any leftover instance, security group etc Milpa created. They
+    # would prevent terraform from destroying the VPC.
+    when    = "destroy"
+    command = "./cleanup-vpc.sh ${self.vpc_id} ${var.cluster-name}"
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      AWS_ACCESS_KEY_ID = "${var.aws-access-key-id}"
+      AWS_SECRET_ACCESS_KEY = "${var.aws-secret-access-key}"
     }
+  }
 }
 
 resource "aws_route_table" "r" {
-    vpc_id = "${aws_vpc.main.id}"
-    route {
-        cidr_block = "0.0.0.0/0"
-        gateway_id = "${aws_internet_gateway.gw.id}"
-    }
+  vpc_id = "${aws_vpc.main.id}"
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.gw.id}"
+  }
 
-    depends_on = ["aws_internet_gateway.gw"]
+  depends_on = ["aws_internet_gateway.gw"]
 
-    tags {
-        Name = "TF_main"
-    }
+  tags {
+    Name = "TF_main"
+  }
 }
 
 resource "aws_route_table_association" "publicA" {
-    subnet_id = "${aws_subnet.publicA.id}"
-    route_table_id = "${aws_route_table.r.id}"
+  subnet_id = "${aws_subnet.publicA.id}"
+  route_table_id = "${aws_route_table.r.id}"
 }
 
 resource "aws_subnet" "publicA" {
-    vpc_id = "${aws_vpc.main.id}"
-    cidr_block = "10.0.100.0/24"
-    availability_zone = "us-east-1c"
-    map_public_ip_on_launch = true
+  vpc_id = "${aws_vpc.main.id}"
+  cidr_block = "10.0.100.0/24"
+  availability_zone = "us-east-1c"
+  map_public_ip_on_launch = true
 
-    tags {
-        Name = "TF_PubSubnetA"
-    }
+  tags {
+    Name = "TF_PubSubnetA"
+  }
 }
 
 resource "aws_security_group" "kubernetes" {
@@ -105,25 +104,25 @@ resource "aws_security_group" "kubernetes" {
   vpc_id = "${aws_vpc.main.id}"
 
   ingress {
-      from_port = 22
-      to_port = 22
-      protocol = "tcp"
-      cidr_blocks = ["0.0.0.0/0"]
+    from_port = 22
+    to_port = 22
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   ingress {
-      from_port = 0
-      to_port = 0
-      protocol = "-1"
-      cidr_blocks = ["10.0.0.0/16"]
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["10.0.0.0/16"]
   }
 
 
   egress {
-      from_port = 0
-      to_port = 0
-      protocol = "-1"
-      cidr_blocks = ["0.0.0.0/0"]
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   tags {
@@ -140,20 +139,20 @@ data "template_file" "master-userdata" {
 }
 
 data "template_file" "worker-userdata" {
-    template = "${file("${var.worker-userdata}")}"
+  template = "${file("${var.worker-userdata}")}"
 
-    vars {
-        k8stoken = "${var.k8stoken}"
-        masterIP = "${aws_instance.k8s-master.private_ip}"
-        cluster_name = "${var.cluster-name}"
-        aws_access_key_id = "${var.aws-access-key-id}"
-        aws_secret_access_key = "${var.aws-secret-access-key}"
-        ssh_key_name = "${var.ssh-key-name}"
-        license_key = "${var.license-key}"
-        license_id = "${var.license-id}"
-        license_username = "${var.license-username}"
-        license_password = "${var.license-password}"
-    }
+  vars {
+    k8stoken = "${var.k8stoken}"
+    masterIP = "${aws_instance.k8s-master.private_ip}"
+    cluster_name = "${var.cluster-name}"
+    aws_access_key_id = "${var.aws-access-key-id}"
+    aws_secret_access_key = "${var.aws-secret-access-key}"
+    ssh_key_name = "${var.ssh-key-name}"
+    license_key = "${var.license-key}"
+    license_id = "${var.license-id}"
+    license_username = "${var.license-username}"
+    license_password = "${var.license-password}"
+  }
 }
 
 resource "aws_instance" "k8s-master" {
@@ -168,7 +167,7 @@ resource "aws_instance" "k8s-master" {
   depends_on = ["aws_internet_gateway.gw"]
 
   tags {
-      Name = "k8s-master"
+    Name = "k8s-master"
   }
 }
 
@@ -180,10 +179,11 @@ resource "aws_instance" "k8s-worker" {
   key_name = "${var.ssh-key-name}"
   associate_public_ip_address = true
   vpc_security_group_ids = ["${aws_security_group.kubernetes.id}"]
+  iam_instance_profile = "${aws_iam_instance_profile.k8s-milpa.id}"
 
   depends_on = ["aws_internet_gateway.gw"]
 
   tags {
-      Name = "k8s-worker"
+    Name = "k8s-worker"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -133,6 +133,21 @@ resource "aws_security_group" "kubernetes" {
   tags = "${local.k8s_cluster_tags}"
 }
 
+resource "aws_security_group" "pod-cidr-to-milpa-nodes" {
+  name = "milpa-nodes-extra"
+  description = "Allow inbound traffic from k8s pods to milpa nodes"
+  vpc_id = "${aws_vpc.main.id}"
+
+  ingress {
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["${var.pod-cidr}"]
+  }
+
+  tags = "${local.k8s_cluster_tags}"
+}
+
 resource "aws_iam_role" "k8s-master" {
   name = "k8s-master-${var.cluster-name}"
   assume_role_policy = <<EOF
@@ -429,6 +444,7 @@ data "template_file" "milpa-worker-userdata" {
     itzo_url = "${var.itzo-url}"
     itzo_version = "${var.itzo-version}"
     milpa_installer_url = "${var.milpa-installer-url}"
+    extra_security_groups = "[\\\"${aws_security_group.pod-cidr-to-milpa-nodes.id}\\\"]"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -40,11 +40,11 @@ resource "aws_vpc" "main" {
         # Remove any leftover instance, security group etc Milpa created. They
         # would prevent terraform from destroying the VPC.
         when    = "destroy"
-        command = "./cleanup-vpc.sh ${self.id} ${var.cluster-name} > /dev/null 2>&1"
+        command = "./cleanup-vpc.sh ${self.id} ${var.cluster-name}"
         interpreter = ["/bin/bash", "-c"]
         environment = {
-            USE_AWS_ACCESS_KEY_ID = "${var.aws-access-key-id}"
-            USE_AWS_SECRET_ACCESS_KEY = "${var.aws-secret-access-key}"
+            AWS_ACCESS_KEY_ID = "${var.aws-access-key-id}"
+            AWS_SECRET_ACCESS_KEY = "${var.aws-secret-access-key}"
         }
     }
 }
@@ -60,11 +60,11 @@ resource "aws_internet_gateway" "gw" {
         # Remove any leftover instance, security group etc Milpa created. They
         # would prevent terraform from destroying the VPC.
         when    = "destroy"
-        command = "./cleanup-vpc.sh ${self.vpc_id} ${var.cluster-name} > /dev/null 2>&1"
+        command = "./cleanup-vpc.sh ${self.vpc_id} ${var.cluster-name}"
         interpreter = ["/bin/bash", "-c"]
         environment = {
-            USE_AWS_ACCESS_KEY_ID = "${var.aws-access-key-id}"
-            USE_AWS_SECRET_ACCESS_KEY = "${var.aws-secret-access-key}"
+            AWS_ACCESS_KEY_ID = "${var.aws-access-key-id}"
+            AWS_SECRET_ACCESS_KEY = "${var.aws-secret-access-key}"
         }
     }
 }

--- a/main.tf
+++ b/main.tf
@@ -418,6 +418,7 @@ data "template_file" "master-userdata" {
 
   vars = {
     k8stoken = "${local.k8stoken}"
+    k8s_version = "${var.k8s-version}"
     pod_cidr = "${var.pod-cidr}"
     service_cidr = "${var.service-cidr}"
     subnet_cidrs = "${join(" ", "${aws_subnet.subnets.*.cidr_block}")}"
@@ -429,6 +430,7 @@ data "template_file" "milpa-worker-userdata" {
 
   vars = {
     k8stoken = "${local.k8stoken}"
+    k8s_version = "${var.k8s-version}"
     masterIP = "${aws_instance.k8s-master.private_ip}"
     service_cidr = "${var.service-cidr}"
     cluster_name = "${var.cluster-name}"
@@ -450,6 +452,7 @@ data "template_file" "worker-userdata" {
 
   vars = {
     k8stoken = "${local.k8stoken}"
+    k8s_version = "${var.k8s-version}"
     masterIP = "${aws_instance.k8s-master.private_ip}"
     pod_cidr = "${var.pod-cidr}"
   }

--- a/main.tf
+++ b/main.tf
@@ -35,6 +35,13 @@ resource "aws_vpc" "main" {
     tags {
         Name = "TF_VPC"
     }
+
+    provisioner "local-exec" {
+        # Remove any leftover security group Milpa created. They would prevent
+        # terraform from destroying the VPC.
+        when    = "destroy"
+        command = "for sg in $(aws ec2 describe-security-groups --filters 'Name=group-name,Values=${var.cluster-name}-*' 'Name=vpc-id,Values=${self.id}' | jq -r '.SecurityGroups | .[] | .GroupId'); do aws ec2 delete-security-group --group-id $sg > /dev/null 2>&1; done"
+    }
 }
 
 resource "aws_internet_gateway" "gw" {

--- a/main.tf
+++ b/main.tf
@@ -128,7 +128,7 @@ resource "aws_security_group" "kubernetes" {
 }
 
 resource "aws_iam_role" "k8s-milpa" {
-  name = "k8s-milpa"
+  name = "k8s-milpa-${var.cluster-name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -146,7 +146,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "k8s-milpa" {
-  name = "k8s-milpa"
+  name = "k8s-milpa-${var.cluster-name}"
   role = "${aws_iam_role.k8s-milpa.id}"
   policy = <<EOF
 {
@@ -232,7 +232,7 @@ EOF
 }
 
 resource  "aws_iam_instance_profile" "k8s-milpa" {
-  name = "k8s-milpa"
+  name = "k8s-milpa-${var.cluster-name}"
   role = "${aws_iam_role.k8s-milpa.name}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -133,21 +133,6 @@ resource "aws_security_group" "kubernetes" {
   tags = "${local.k8s_cluster_tags}"
 }
 
-resource "aws_security_group" "pod-cidr-to-milpa-nodes" {
-  name = "milpa-nodes-extra"
-  description = "Allow inbound traffic from k8s pods to milpa nodes"
-  vpc_id = "${aws_vpc.main.id}"
-
-  ingress {
-    from_port = 0
-    to_port = 0
-    protocol = "-1"
-    cidr_blocks = ["${var.pod-cidr}"]
-  }
-
-  tags = "${local.k8s_cluster_tags}"
-}
-
 resource "aws_iam_role" "k8s-master" {
   name = "k8s-master-${var.cluster-name}"
   assume_role_policy = <<EOF
@@ -444,7 +429,7 @@ data "template_file" "milpa-worker-userdata" {
     itzo_url = "${var.itzo-url}"
     itzo_version = "${var.itzo-version}"
     milpa_installer_url = "${var.milpa-installer-url}"
-    extra_security_groups = "[\\\"${aws_security_group.pod-cidr-to-milpa-nodes.id}\\\"]"
+    pod_cidr = "${var.pod-cidr}"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -423,7 +423,7 @@ data "template_file" "master-userdata" {
     k8stoken = "${local.k8stoken}"
     pod_cidr = "${var.pod-cidr}"
     service_cidr = "${var.service-cidr}"
-    non_masquerade_cidr = "${var.non-masquerade-cidr}"
+    subnet_cidr = "${var.subnet-cidr}"
   }
 }
 
@@ -455,7 +455,6 @@ data "template_file" "worker-userdata" {
     k8stoken = "${local.k8stoken}"
     masterIP = "${aws_instance.k8s-master.private_ip}"
     pod_cidr = "${var.pod-cidr}"
-    non_masquerade_cidr = "${var.non-masquerade-cidr}"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -434,8 +434,24 @@ data "template_file" "worker-userdata" {
   }
 }
 
+data "aws_ami" "ubuntu" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  owners = ["099720109477"] # Canonical.
+}
+
 resource "aws_instance" "k8s-master" {
-  ami           = "ami-2ef48339"
+  ami           = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.medium"
   subnet_id = "${aws_subnet.publicA.id}"
   user_data = "${data.template_file.master-userdata.rendered}"
@@ -450,7 +466,7 @@ resource "aws_instance" "k8s-master" {
 }
 
 resource "aws_instance" "k8s-milpa-worker" {
-  ami           = "ami-2ef48339"
+  ami           = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.medium"
   subnet_id = "${aws_subnet.publicA.id}"
   user_data = "${data.template_file.milpa-worker-userdata.rendered}"
@@ -465,7 +481,7 @@ resource "aws_instance" "k8s-milpa-worker" {
 }
 
 resource "aws_instance" "k8s-worker" {
-  ami           = "ami-2ef48339"
+  ami           = "${data.aws_ami.ubuntu.id}"
   instance_type = "t2.medium"
   subnet_id = "${aws_subnet.publicA.id}"
   user_data = "${data.template_file.worker-userdata.rendered}"

--- a/main.tf
+++ b/main.tf
@@ -34,8 +34,12 @@ locals {
   )}"
 }
 
-resource "random_shuffle" "az" {
-  input = ["${var.region}a", "${var.region}b", "${var.region}c", "${var.region}d", "${var.region}e", ]
+data "aws_availability_zones" "available-azs" {
+  state = "available"
+}
+
+resource "random_shuffle" "azs" {
+  input = ["${data.aws_availability_zones.available-azs.names}"]
   result_count = "${var.number-of-subnets}"
 }
 
@@ -80,7 +84,7 @@ resource "aws_subnet" "subnets" {
   count = "${var.number-of-subnets}"
   vpc_id = "${aws_vpc.main.id}"
   cidr_block = "${cidrsubnet("${var.vpc-cidr}", 4, "${count.index+1}")}"
-  availability_zone = "${element("${random_shuffle.az.result}", count.index)}"
+  availability_zone = "${element("${random_shuffle.azs.result}", count.index)}"
   map_public_ip_on_launch = true
 
   tags = "${local.k8s_cluster_tags}"

--- a/main.tf
+++ b/main.tf
@@ -127,8 +127,8 @@ resource "aws_security_group" "kubernetes" {
   tags = "${local.k8s_cluster_tags}"
 }
 
-resource "aws_iam_role" "k8s-milpa" {
-  name = "k8s-milpa-${var.cluster-name}"
+resource "aws_iam_role" "k8s-master" {
+  name = "k8s-master-${var.cluster-name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -145,9 +145,106 @@ resource "aws_iam_role" "k8s-milpa" {
 EOF
 }
 
-resource "aws_iam_role_policy" "k8s-milpa" {
-  name = "k8s-milpa-${var.cluster-name}"
-  role = "${aws_iam_role.k8s-milpa.id}"
+resource "aws_iam_role_policy" "k8s-master" {
+  name = "k8s-master-${var.cluster-name}"
+  role = "${aws_iam_role.k8s-master.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeLaunchConfigurations",
+        "autoscaling:DescribeTags",
+        "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
+        "ec2:DescribeRouteTables",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVolumes",
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateTags",
+        "ec2:CreateVolume",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:ModifyVolume",
+        "ec2:AttachVolume",
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateRoute",
+        "ec2:DeleteRoute",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DeleteVolume",
+        "ec2:DetachVolume",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:DescribeVpcs",
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:AttachLoadBalancerToSubnets",
+        "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateLoadBalancerPolicy",
+        "elasticloadbalancing:CreateLoadBalancerListeners",
+        "elasticloadbalancing:ConfigureHealthCheck",
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:DeleteLoadBalancerListeners",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeLoadBalancerAttributes",
+        "elasticloadbalancing:DetachLoadBalancerFromSubnets",
+        "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+        "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer",
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:CreateTargetGroup",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:DeleteTargetGroup",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeLoadBalancerPolicies",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetHealth",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:ModifyTargetGroup",
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
+        "iam:CreateServiceLinkedRole",
+        "kms:DescribeKey"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource  "aws_iam_instance_profile" "k8s-master" {
+  name = "k8s-master-${var.cluster-name}"
+  role = "${aws_iam_role.k8s-master.name}"
+}
+
+resource "aws_iam_role" "k8s-milpa-worker" {
+  name = "k8s-milpa-worker-${var.cluster-name}"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "k8s-milpa-worker" {
+  name = "k8s-milpa-worker-${var.cluster-name}"
+  role = "${aws_iam_role.k8s-milpa-worker.id}"
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -231,9 +328,9 @@ resource "aws_iam_role_policy" "k8s-milpa" {
 EOF
 }
 
-resource  "aws_iam_instance_profile" "k8s-milpa" {
-  name = "k8s-milpa-${var.cluster-name}"
-  role = "${aws_iam_role.k8s-milpa.name}"
+resource  "aws_iam_instance_profile" "k8s-milpa-worker" {
+  name = "k8s-milpa-worker-${var.cluster-name}"
+  role = "${aws_iam_role.k8s-milpa-worker.name}"
 }
 
 data "template_file" "master-userdata" {
@@ -269,7 +366,7 @@ resource "aws_instance" "k8s-master" {
   key_name = "${var.ssh-key-name}"
   associate_public_ip_address = true
   vpc_security_group_ids = ["${aws_security_group.kubernetes.id}"]
-  iam_instance_profile = "${aws_iam_instance_profile.k8s-milpa.id}"
+  iam_instance_profile = "${aws_iam_instance_profile.k8s-master.id}"
 
   depends_on = ["aws_internet_gateway.gw"]
 
@@ -284,7 +381,7 @@ resource "aws_instance" "k8s-worker" {
   key_name = "${var.ssh-key-name}"
   associate_public_ip_address = true
   vpc_security_group_ids = ["${aws_security_group.kubernetes.id}"]
-  iam_instance_profile = "${aws_iam_instance_profile.k8s-milpa.id}"
+  iam_instance_profile = "${aws_iam_instance_profile.k8s-milpa-worker.id}"
 
   depends_on = ["aws_internet_gateway.gw"]
 

--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ locals {
 }
 
 resource "aws_vpc" "main" {
-  cidr_block = "10.0.0.0/16"
+  cidr_block = "${var.vpc-cidr}"
   enable_dns_hostnames = true
 
   tags = "${local.k8s_cluster_tags}"
@@ -71,6 +71,15 @@ resource "aws_internet_gateway" "gw" {
   }
 }
 
+resource "aws_subnet" "publicA" {
+  vpc_id = "${aws_vpc.main.id}"
+  cidr_block = "${var.subnet-cidr}"
+  availability_zone = "us-east-1a"
+  map_public_ip_on_launch = true
+
+  tags = "${local.k8s_cluster_tags}"
+}
+
 resource "aws_route_table" "r" {
   vpc_id = "${aws_vpc.main.id}"
   route {
@@ -86,15 +95,6 @@ resource "aws_route_table" "r" {
 resource "aws_route_table_association" "publicA" {
   subnet_id = "${aws_subnet.publicA.id}"
   route_table_id = "${aws_route_table.r.id}"
-}
-
-resource "aws_subnet" "publicA" {
-  vpc_id = "${aws_vpc.main.id}"
-  cidr_block = "10.0.100.0/24"
-  availability_zone = "us-east-1c"
-  map_public_ip_on_launch = true
-
-  tags = "${local.k8s_cluster_tags}"
 }
 
 resource "aws_security_group" "kubernetes" {
@@ -113,9 +113,15 @@ resource "aws_security_group" "kubernetes" {
     from_port = 0
     to_port = 0
     protocol = "-1"
-    cidr_blocks = ["10.0.0.0/16"]
+    cidr_blocks = ["${var.vpc-cidr}"]
   }
 
+  ingress {
+    from_port = 0
+    to_port = 0
+    protocol = "-1"
+    cidr_blocks = ["${var.pod-cidr}"]
+  }
 
   egress {
     from_port = 0
@@ -333,11 +339,83 @@ resource  "aws_iam_instance_profile" "k8s-milpa-worker" {
   role = "${aws_iam_role.k8s-milpa-worker.name}"
 }
 
+resource "aws_iam_role" "k8s-worker" {
+  name = "k8s-worker-${var.cluster-name}"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "k8s-worker" {
+  name = "k8s-worker-${var.cluster-name}"
+  role = "${aws_iam_role.k8s-worker.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeInstances",
+        "ec2:DescribeRegions",
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:GetRepositoryPolicy",
+        "ecr:DescribeRepositories",
+        "ecr:ListImages",
+        "ecr:BatchGetImage"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource  "aws_iam_instance_profile" "k8s-worker" {
+  name = "k8s-worker-${var.cluster-name}"
+  role = "${aws_iam_role.k8s-worker.name}"
+}
+
 data "template_file" "master-userdata" {
   template = "${file("${var.master-userdata}")}"
 
   vars {
     k8stoken = "${var.k8stoken}"
+    pod_cidr = "${var.pod-cidr}"
+    service_cidr = "${var.service-cidr}"
+  }
+}
+
+data "template_file" "milpa-worker-userdata" {
+  template = "${file("${var.milpa-worker-userdata}")}"
+
+  vars {
+    k8stoken = "${var.k8stoken}"
+    masterIP = "${aws_instance.k8s-master.private_ip}"
+    service_cidr = "${var.service-cidr}"
+    cluster_name = "${var.cluster-name}"
+    aws_access_key_id = "${var.aws-access-key-id}"
+    aws_secret_access_key = "${var.aws-secret-access-key}"
+    license_key = "${var.license-key}"
+    license_id = "${var.license-id}"
+    license_username = "${var.license-username}"
+    license_password = "${var.license-password}"
+    itzo_url = "${var.itzo-url}"
+    itzo_version = "${var.itzo-version}"
+    milpa_installer_url = "${var.milpa-installer-url}"
   }
 }
 
@@ -347,17 +425,7 @@ data "template_file" "worker-userdata" {
   vars {
     k8stoken = "${var.k8stoken}"
     masterIP = "${aws_instance.k8s-master.private_ip}"
-    cluster_name = "${var.cluster-name}"
-    aws_access_key_id = "${var.aws-access-key-id}"
-    aws_secret_access_key = "${var.aws-secret-access-key}"
-    ssh_key_name = "${var.ssh-key-name}"
-    license_key = "${var.license-key}"
-    license_id = "${var.license-id}"
-    license_username = "${var.license-username}"
-    license_password = "${var.license-password}"
-    itzo_url = "${var.itzo-url}"
-    itzo_version = "${var.itzo-version}"
-    milpa_installer_url = "${var.milpa-installer-url}"
+    pod_cidr = "${var.pod-cidr}"
   }
 }
 
@@ -376,6 +444,21 @@ resource "aws_instance" "k8s-master" {
   tags = "${local.k8s_cluster_tags}"
 }
 
+resource "aws_instance" "k8s-milpa-worker" {
+  ami           = "ami-2ef48339"
+  instance_type = "t2.medium"
+  subnet_id = "${aws_subnet.publicA.id}"
+  user_data = "${data.template_file.milpa-worker-userdata.rendered}"
+  key_name = "${var.ssh-key-name}"
+  associate_public_ip_address = true
+  vpc_security_group_ids = ["${aws_security_group.kubernetes.id}"]
+  iam_instance_profile = "${aws_iam_instance_profile.k8s-milpa-worker.id}"
+
+  depends_on = ["aws_internet_gateway.gw"]
+
+  tags = "${local.k8s_cluster_tags}"
+}
+
 resource "aws_instance" "k8s-worker" {
   ami           = "ami-2ef48339"
   instance_type = "t2.medium"
@@ -384,7 +467,7 @@ resource "aws_instance" "k8s-worker" {
   key_name = "${var.ssh-key-name}"
   associate_public_ip_address = true
   vpc_security_group_ids = ["${aws_security_group.kubernetes.id}"]
-  iam_instance_profile = "${aws_iam_instance_profile.k8s-milpa-worker.id}"
+  iam_instance_profile = "${aws_iam_instance_profile.k8s-worker.id}"
 
   depends_on = ["aws_internet_gateway.gw"]
 

--- a/main.tf
+++ b/main.tf
@@ -47,8 +47,8 @@ resource "aws_vpc" "main" {
     command = "./cleanup-vpc.sh ${self.id} ${var.cluster-name}"
     interpreter = ["/bin/bash", "-c"]
     environment = {
-      AWS_ACCESS_KEY_ID = "${var.aws-access-key-id}"
-      AWS_SECRET_ACCESS_KEY = "${var.aws-secret-access-key}"
+      "AWS_REGION" = "${var.region}"
+      "AWS_DEFAULT_REGION" = "${var.region}"
     }
   }
 }
@@ -65,8 +65,8 @@ resource "aws_internet_gateway" "gw" {
     command = "./cleanup-vpc.sh ${self.vpc_id} ${var.cluster-name}"
     interpreter = ["/bin/bash", "-c"]
     environment = {
-      AWS_ACCESS_KEY_ID = "${var.aws-access-key-id}"
-      AWS_SECRET_ACCESS_KEY = "${var.aws-secret-access-key}"
+      "AWS_REGION" = "${var.region}"
+      "AWS_DEFAULT_REGION" = "${var.region}"
     }
   }
 }
@@ -153,29 +153,78 @@ resource "aws_iam_role_policy" "k8s-milpa" {
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Action": ["ec2:*"],
+      "Sid": "ec2",
       "Effect": "Allow",
-      "Resource": ["*"]
-    },
-    {
-      "Action": ["elasticloadbalancing:*"],
-      "Effect": "Allow",
-      "Resource": ["*"]
-    },
-    {
-      "Action": ["route53:*"],
-      "Effect": "Allow",
-      "Resource": ["*"]
-    },
-    {
-      "Action": ["ecr:*"],
-      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateRoute",
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateTags",
+        "ec2:CreateVolume",
+        "ec2:DeleteRoute",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DescribeAddresses",
+        "ec2:DescribeElasticGpus",
+        "ec2:DescribeImages",
+        "ec2:DescribeInstances",
+        "ec2:DescribeRouteTables",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSpotPriceHistory",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeTags",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeVpcAttribute",
+        "ec2:DescribeVpcs",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:ModifyInstanceCreditSpecification",
+        "ec2:ModifyVolume",
+        "ec2:ModifyVpcAttribute",
+        "ec2:RequestSpotInstances",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:RunInstances",
+        "ec2:TerminateInstances",
+        "ecr:BatchGetImage",
+        "ecr:GetAuthorizationToken",
+        "ecr:GetDownloadUrlForLayer",
+        "elasticloadbalancing:DescribeLoadBalancerAttributes",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeTags",
+        "route53:ChangeResourceRecordSets",
+        "route53:CreateHostedZone",
+        "route53:GetChange",
+        "route53:ListHostedZonesByName",
+        "route53:ListResourceRecordSets"
+      ],
       "Resource": "*"
     },
     {
-      "Action": ["dynamodb:*"],
+      "Sid": "dynamo",
       "Effect": "Allow",
-      "Resource": "arn:aws:dynamodb:::MilpaClusters"
+      "Action": [
+        "dynamodb:CreateTable",
+        "dynamodb:PutItem",
+        "dynamodb:DescribeTable",
+        "dynamodb:GetItem"
+      ],
+      "Resource": "arn:aws:dynamodb:*:*:table/MilpaClusters"
+    },
+    {
+      "Sid": "elb",
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:RemoveTags",
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:ConfigureHealthCheck",
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
+        "elasticloadbalancing:DeleteLoadBalancerListeners",
+        "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+        "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:CreateLoadBalancerListeners"
+      ],
+      "Resource": "arn:aws:elasticloadbalancing:*:*:loadbalancer/milpa-*"
     }
   ]
 }

--- a/master.sh
+++ b/master.sh
@@ -50,6 +50,11 @@ controllerManager:
     cloud-provider: aws
     configure-cloud-routes: "true"
     address: 0.0.0.0
+---
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
+kind: KubeProxyConfiguration
+iptables:
+  masqueradeAll: true
 EOF
 kubeadm init --config=/tmp/kubeadm-config.yaml
 
@@ -59,8 +64,6 @@ export KUBECONFIG=/etc/kubernetes/admin.conf
 mkdir -p /home/ubuntu/.kube
 sudo cp -i $KUBECONFIG /home/ubuntu/.kube/config
 sudo chown ubuntu: /home/ubuntu/.kube/config
-
-kubectl get cm -n kube-system kube-proxy -oyaml | sed -r '/^\s+resourceVersion:/d' | sed 's/masqueradeAll: false/masqueradeAll: true/' | kubectl replace -f -
 
 kubectl patch -n kube-system deployment kube-dns --patch '{"spec": {"template": {"spec": {"tolerations": [{"key": "CriticalAddonsOnly", "operator": "Exists"}]}}}}'
 

--- a/master.sh
+++ b/master.sh
@@ -36,8 +36,6 @@ nodeRegistration:
 ---
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
-dns:
-  type: kube-dns
 networking:
   podSubnet: ${pod_cidr}
   serviceSubnet: ${service_cidr}
@@ -64,8 +62,6 @@ export KUBECONFIG=/etc/kubernetes/admin.conf
 mkdir -p /home/ubuntu/.kube
 sudo cp -i $KUBECONFIG /home/ubuntu/.kube/config
 sudo chown ubuntu: /home/ubuntu/.kube/config
-
-kubectl patch -n kube-system deployment kube-dns --patch '{"spec": {"template": {"spec": {"tolerations": [{"key": "CriticalAddonsOnly", "operator": "Exists"}]}}}}'
 
 cat <<EOF > /tmp/storageclass.yaml
 kind: StorageClass

--- a/master.sh
+++ b/master.sh
@@ -20,6 +20,8 @@ bootstrapTokens:
   token: ${k8stoken}
 nodeRegistration:
   name: $(hostname -f)
+  kubeletExtraArgs:
+    cloud-provider: aws
 ---
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration
@@ -31,7 +33,7 @@ networking:
 apiServer:
   extraArgs:
     enable-admission-plugins: DefaultStorageClass,NodeRestriction
-#    cloud-provider: aws
+    cloud-provider: aws
 controllerManager:
   extraArgs:
     cloud-provider: aws

--- a/master.sh
+++ b/master.sh
@@ -28,8 +28,8 @@ kind: ClusterConfiguration
 dns:
   type: kube-dns
 networking:
-  podSubnet: 172.20.0.0/16
-  serviceSubnet: 10.96.0.0/12
+  podSubnet: ${pod_cidr}
+  serviceSubnet: ${service_cidr}
 apiServer:
   extraArgs:
     enable-admission-plugins: DefaultStorageClass,NodeRestriction
@@ -37,7 +37,7 @@ apiServer:
 controllerManager:
   extraArgs:
     cloud-provider: aws
-    configure-cloud-routes: "false"
+    configure-cloud-routes: "true"
     address: 0.0.0.0
 EOF
 kubeadm init --node-name=$(hostname -f) --config=/tmp/kubeadm-config.yaml

--- a/master.sh
+++ b/master.sh
@@ -5,9 +5,7 @@ cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -y kubelet kubeadm kubectl kubernetes-cni
-curl -sSL https://get.docker.com/ | sh
-systemctl start docker
+apt-get install -y kubelet kubeadm kubectl kubernetes-cni docker.io
 
 # Docker sets the policy for the FORWARD chain to DROP, change it back.
 iptables -P FORWARD ACCEPT

--- a/master.sh
+++ b/master.sh
@@ -53,3 +53,16 @@ sudo chown ubuntu: /home/ubuntu/.kube/config
 kubectl get cm -n kube-system kube-proxy -oyaml | sed -r '/^\s+resourceVersion:/d' | sed 's/masqueradeAll: false/masqueradeAll: true/' | kubectl replace -f -
 
 kubectl patch -n kube-system deployment kube-dns --patch '{"spec": {"template": {"spec": {"tolerations": [{"key": "CriticalAddonsOnly", "operator": "Exists"}]}}}}'
+
+cat <<EOF > /tmp/storageclass.yaml
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: ebs
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/aws-ebs
+volumeBindingMode: Immediate
+reclaimPolicy: Retain
+EOF
+kubectl apply -f /tmp/storageclass.yaml

--- a/master.sh
+++ b/master.sh
@@ -5,7 +5,7 @@ cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -y kubelet=${k8s_version} kubeadm=${k8s_version} kubectl=${k8s_version} kubernetes-cni docker.io
+apt-get install -y kubelet=${k8s_version} kubeadm=${k8s_version} kubectl=${k8s_version} kubernetes-cni docker.io python-pip jq
 
 # Docker sets the policy for the FORWARD chain to DROP, change it back.
 iptables -P FORWARD ACCEPT

--- a/master.sh
+++ b/master.sh
@@ -88,3 +88,4 @@ $(for subnet in ${subnet_cidrs}; do echo "  - $subnet"; done)
 EOF
 kubectl create -n kube-system configmap ip-masq-agent --from-file=/tmp/ip-masq-agent-config/config
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-incubator/ip-masq-agent/master/ip-masq-agent.yaml
+kubectl patch -n kube-system daemonset ip-masq-agent --patch '{"spec":{"template":{"spec":{"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"}]}}}}'

--- a/master.sh
+++ b/master.sh
@@ -81,7 +81,7 @@ mkdir -p /tmp/ip-masq-agent-config
 cat <<EOF > /tmp/ip-masq-agent-config/config
 nonMasqueradeCIDRs:
   - ${pod_cidr}
-  - ${subnet_cidr}
+$(for subnet in ${subnet_cidrs}; do echo "  - $subnet"; done)
 EOF
 kubectl create -n kube-system configmap ip-masq-agent --from-file=/tmp/ip-masq-agent-config/config
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-incubator/ip-masq-agent/master/ip-masq-agent.yaml

--- a/master.sh
+++ b/master.sh
@@ -9,6 +9,13 @@ apt-get install -y kubelet kubeadm kubectl kubernetes-cni
 curl -sSL https://get.docker.com/ | sh
 systemctl start docker
 
-kubeadm init --token=${k8stoken}
+sysctl net.bridge.bridge-nf-call-iptables=1
 
-kubectl apply -f https://git.io/weave-kube
+kubeadm init --token=${k8stoken} --pod-network-cidr=172.20.0.0/16
+
+echo 'KUBELET_KUBEADM_ARGS=--cgroup-driver=cgroupfs --pod-infra-container-image=k8s.gcr.io/pause:3.1' > /var/lib/kubelet/kubeadm-flags.env
+systemctl restart kubelet
+
+mkdir -p /home/ubuntu/.kube
+sudo cp -i /etc/kubernetes/admin.conf /home/ubuntu/.kube/config
+sudo chown ubuntu: /home/ubuntu/.kube/config

--- a/master.sh
+++ b/master.sh
@@ -11,11 +11,34 @@ systemctl start docker
 
 sysctl net.bridge.bridge-nf-call-iptables=1
 
-kubeadm init --token=${k8stoken} --pod-network-cidr=172.20.0.0/16
+cat <<EOF > /tmp/kubeadm-config.yaml
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: InitConfiguration
+bootstrapTokens:
+- groups:
+  - system:bootstrappers:kubeadm:default-node-token
+  token: ${k8stoken}
+---
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: ClusterConfiguration
+dns:
+  type: kube-dns
+networking:
+  podSubnet: 172.20.0.0/16
+  serviceSubnet: 10.96.0.0/12
+EOF
+kubeadm init --config=/tmp/kubeadm-config.yaml
 
 echo 'KUBELET_KUBEADM_ARGS=--cgroup-driver=cgroupfs --pod-infra-container-image=k8s.gcr.io/pause:3.1' > /var/lib/kubelet/kubeadm-flags.env
 systemctl restart kubelet
 
+export KUBECONFIG=/etc/kubernetes/admin.conf
+
+# Configure kubectl.
 mkdir -p /home/ubuntu/.kube
-sudo cp -i /etc/kubernetes/admin.conf /home/ubuntu/.kube/config
+sudo cp -i $KUBECONFIG /home/ubuntu/.kube/config
 sudo chown ubuntu: /home/ubuntu/.kube/config
+
+kubectl get cm -n kube-system kube-proxy -oyaml | sed -r '/^\s+resourceVersion:/d' | sed 's/masqueradeAll: false/masqueradeAll: true/' | kubectl replace -f -
+
+kubectl patch -n kube-system deployment kube-dns --patch '{"spec": {"template": {"spec": {"tolerations": [{"key": "CriticalAddonsOnly", "operator": "Exists"}]}}}}'

--- a/master.sh
+++ b/master.sh
@@ -9,9 +9,7 @@ apt-get install -y kubelet kubeadm kubectl kubernetes-cni
 curl -sSL https://get.docker.com/ | sh
 systemctl start docker
 
-modprobe br_netfilter
-sysctl net.bridge.bridge-nf-call-iptables=1
-sysctl net.ipv4.ip_forward=1
+# Docker sets the policy for the FORWARD chain to DROP, change it back.
 iptables -P FORWARD ACCEPT
 
 name=""

--- a/master.sh
+++ b/master.sh
@@ -83,3 +83,61 @@ EOF
 kubectl create -n kube-system configmap ip-masq-agent --from-file=/tmp/ip-masq-agent-config/config
 kubectl apply -f https://raw.githubusercontent.com/kubernetes-incubator/ip-masq-agent/master/ip-masq-agent.yaml
 kubectl patch -n kube-system daemonset ip-masq-agent --patch '{"spec":{"template":{"spec":{"tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master"}]}}}}'
+
+# Start a kube-proxy deployment for Milpa. This will route cluster IP traffic
+# from Milpa pods.
+cat <<EOF > /tmp/kube-proxy-milpa.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: kube-proxy
+  name: kube-proxy
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-proxy
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-proxy
+      annotations:
+        kubernetes.io/target-runtime: kiyot
+    spec:
+      nodeSelector:
+        kubernetes.io/role: milpa-worker
+      containers:
+      - command:
+        - /usr/local/bin/kube-proxy
+        - --config=/var/lib/kube-proxy/config.conf
+        - --hostname-override=$(NODE_NAME)
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.nodeName
+        image: k8s.gcr.io/kube-proxy:v1.15.0
+        name: kube-proxy
+        resources: {}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /var/lib/kube-proxy
+          name: kube-proxy
+      dnsPolicy: ClusterFirst
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      restartPolicy: Always
+      securityContext: {}
+      serviceAccount: kube-proxy
+      serviceAccountName: kube-proxy
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: kube-proxy
+        name: kube-proxy
+EOF
+kubectl apply -f /tmp/kube-proxy-milpa.yaml

--- a/master.sh
+++ b/master.sh
@@ -63,6 +63,7 @@ mkdir -p /home/ubuntu/.kube
 sudo cp -i $KUBECONFIG /home/ubuntu/.kube/config
 sudo chown ubuntu: /home/ubuntu/.kube/config
 
+# Create a default storage class, backed by EBS.
 cat <<EOF > /tmp/storageclass.yaml
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -76,6 +77,7 @@ reclaimPolicy: Retain
 EOF
 kubectl apply -f /tmp/storageclass.yaml
 
+# Set up ip-masq-agent.
 mkdir -p /tmp/ip-masq-agent-config
 cat <<EOF > /tmp/ip-masq-agent-config/config
 nonMasqueradeCIDRs:

--- a/master.sh
+++ b/master.sh
@@ -5,7 +5,7 @@ cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -y kubelet kubeadm kubectl kubernetes-cni docker.io
+apt-get install -y kubelet=${k8s_version} kubeadm=${k8s_version} kubectl=${k8s_version} kubernetes-cni docker.io
 
 # Docker sets the policy for the FORWARD chain to DROP, change it back.
 iptables -P FORWARD ACCEPT

--- a/master.sh
+++ b/master.sh
@@ -14,7 +14,8 @@ sysctl net.bridge.bridge-nf-call-iptables=1
 sysctl net.ipv4.ip_forward=1
 iptables -P FORWARD ACCEPT
 
-if [[ -z "${non_masquerade_cidr}" ]]; then
+non_masquerade_cidr="${non_masquerade_cidr}"
+if [[ -z "$non_masquerade_cidr" ]]; then
     non_masquerade_cidr="${pod_cidr}"
 fi
 
@@ -36,7 +37,7 @@ nodeRegistration:
   kubeletExtraArgs:
     cloud-provider: aws
     network-plugin: kubenet
-    non-masquerade-cidr: ${non_masquerade_cidr}
+    non-masquerade-cidr: $non_masquerade_cidr
 ---
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: ClusterConfiguration

--- a/milpa-worker.sh
+++ b/milpa-worker.sh
@@ -5,7 +5,7 @@ cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -y kubelet=${k8s_version} kubeadm=${k8s_version} kubectl=${k8s_version} kubernetes-cni docker.io
+apt-get install -y kubelet=${k8s_version} kubeadm=${k8s_version} kubectl=${k8s_version} kubernetes-cni docker.io python-pip jq
 
 name=""
 while [[ -z "$name" ]]; do

--- a/milpa-worker.sh
+++ b/milpa-worker.sh
@@ -7,6 +7,12 @@ EOF
 apt-get update
 apt-get install -y kubelet kubeadm kubectl kubernetes-cni python python-pip jq docker.io
 
+name=""
+while [[ -z "$name" ]]; do
+    sleep 1
+    name="$(hostname -f)"
+done
+
 cat <<EOF > /tmp/kubeadm-config.yaml
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: JoinConfiguration
@@ -16,7 +22,7 @@ discovery:
     unsafeSkipCAVerification: true
     apiServerEndpoint: ${masterIP}:6443
 nodeRegistration:
-  name: $(hostname -f)
+  name: $name
 #  criSocket: unix:///opt/milpa/run/kiyot.sock
   kubeletExtraArgs:
     cloud-provider: aws

--- a/milpa-worker.sh
+++ b/milpa-worker.sh
@@ -1,0 +1,54 @@
+#!/bin/bash -v
+
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
+deb http://apt.kubernetes.io/ kubernetes-xenial main
+EOF
+apt-get update
+apt-get install -y kubelet kubeadm kubectl kubernetes-cni python python-pip jq docker.io
+
+cat <<EOF > /tmp/kubeadm-config.yaml
+apiVersion: kubeadm.k8s.io/v1beta1
+kind: JoinConfiguration
+discovery:
+  bootstrapToken:
+    token: ${k8stoken}
+    unsafeSkipCAVerification: true
+    apiServerEndpoint: ${masterIP}:6443
+nodeRegistration:
+  name: $(hostname -f)
+#  criSocket: unix:///opt/milpa/run/kiyot.sock
+  kubeletExtraArgs:
+    cloud-provider: aws
+    max-pods: "1000"
+EOF
+
+modprobe br_netfilter
+sysctl net.bridge.bridge-nf-call-iptables=1
+sysctl net.ipv4.ip_forward=1
+
+curl -L ${milpa_installer_url} > milpa-installer-latest
+chmod 755 milpa-installer-latest
+./milpa-installer-latest
+
+pip install yq
+yq -y ".clusterName=\"${cluster_name}\" | .cloud.aws.accessKeyID=\"${aws_access_key_id}\" | .cloud.aws.secretAccessKey=\"${aws_secret_access_key}\" | .cloud.aws.vpcID=\"\" | .nodes.itzo.url=\"${itzo_url}\" | .nodes.itzo.version=\"${itzo_version}\" | .license.key=\"${license_key}\" | .license.id=\"${license_id}\" | .license.username=\"${license_username}\" | .license.password=\"${license_password}\"" /opt/milpa/etc/server.yml > /opt/milpa/etc/server.yml.new && mv /opt/milpa/etc/server.yml.new /opt/milpa/etc/server.yml
+sed -i 's#--milpa-endpoint 127.0.0.1:54555$#--milpa-endpoint 127.0.0.1:54555 --service-cluster-ip-range ${service_cidr} --kubeconfig /etc/kubernetes/kubelet.conf#' /etc/systemd/system/kiyot.service
+sed -i 's#--config /opt/milpa/etc/server.yml$#--config /opt/milpa/etc/server.yml --delete-cluster-lock-file#' /etc/systemd/system/milpa.service
+mkdir -p /etc/systemd/system/kubelet.service.d/
+echo -e "[Service]\nStartLimitInterval=0\nStartLimitIntervalSec=0\nRestart=always\nRestartSec=5" > /etc/systemd/system/kubelet.service.d/override.conf
+
+for i in {1..50}; do kubeadm join --config=/tmp/kubeadm-config.yaml && break || sleep 15; done
+
+# TODO: have kiyot retry creating k8s client and connect to the API server, and
+# have kubeadm configure the CRI. Then we can override all the extra parameters
+# via kubeletExtraArgs, and don't need to update kubeadm-flags.env here.
+echo "KUBELET_KUBEADM_ARGS=--cloud-provider=aws --hostname-override=$(hostname -f) --cgroup-driver=cgroupfs --pod-infra-container-image=k8s.gcr.io/pause:3.1 --container-runtime=remote --container-runtime-endpoint=unix:///opt/milpa/run/kiyot.sock --max-pods=1000" > /var/lib/kubelet/kubeadm-flags.env
+
+systemctl daemon-reload
+systemctl restart milpa
+systemctl restart kiyot
+systemctl restart kubelet
+
+docker ps -aq --no-trunc | xargs docker stop
+docker ps -aq --no-trunc | xargs docker rm

--- a/milpa-worker.sh
+++ b/milpa-worker.sh
@@ -27,6 +27,7 @@ nodeRegistration:
   kubeletExtraArgs:
     cloud-provider: aws
     max-pods: "1000"
+    node-labels: kubernetes.io/role=milpa-worker
 EOF
 
 modprobe br_netfilter

--- a/milpa-worker.sh
+++ b/milpa-worker.sh
@@ -38,7 +38,7 @@ chmod 755 milpa-installer-latest
 ./milpa-installer-latest
 
 pip install yq
-yq -y ".clusterName=\"${cluster_name}\" | .cloud.aws.accessKeyID=\"${aws_access_key_id}\" | .cloud.aws.secretAccessKey=\"${aws_secret_access_key}\" | .cloud.aws.vpcID=\"\" | .nodes.itzo.url=\"${itzo_url}\" | .nodes.itzo.version=\"${itzo_version}\" | .license.key=\"${license_key}\" | .license.id=\"${license_id}\" | .license.username=\"${license_username}\" | .license.password=\"${license_password}\"" /opt/milpa/etc/server.yml > /opt/milpa/etc/server.yml.new && mv /opt/milpa/etc/server.yml.new /opt/milpa/etc/server.yml
+yq -y ".clusterName=\"${cluster_name}\" | .cloud.aws.accessKeyID=\"${aws_access_key_id}\" | .cloud.aws.secretAccessKey=\"${aws_secret_access_key}\" | .cloud.aws.vpcID=\"\" | .nodes.itzo.url=\"${itzo_url}\" | .nodes.itzo.version=\"${itzo_version}\" | .nodes.extraSecurityGroups=${extra_security_groups} | .license.key=\"${license_key}\" | .license.id=\"${license_id}\" | .license.username=\"${license_username}\" | .license.password=\"${license_password}\"" /opt/milpa/etc/server.yml > /opt/milpa/etc/server.yml.new && mv /opt/milpa/etc/server.yml.new /opt/milpa/etc/server.yml
 sed -i 's#--milpa-endpoint 127.0.0.1:54555$#--milpa-endpoint 127.0.0.1:54555 --service-cluster-ip-range ${service_cidr} --kubeconfig /etc/kubernetes/kubelet.conf#' /etc/systemd/system/kiyot.service
 sed -i 's#--config /opt/milpa/etc/server.yml$#--config /opt/milpa/etc/server.yml --delete-cluster-lock-file#' /etc/systemd/system/milpa.service
 mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/milpa-worker.sh
+++ b/milpa-worker.sh
@@ -30,10 +30,6 @@ nodeRegistration:
     node-labels: kubernetes.io/role=milpa-worker
 EOF
 
-modprobe br_netfilter
-sysctl net.bridge.bridge-nf-call-iptables=1
-sysctl net.ipv4.ip_forward=1
-
 curl -L ${milpa_installer_url} > milpa-installer-latest
 chmod 755 milpa-installer-latest
 ./milpa-installer-latest

--- a/milpa-worker.sh
+++ b/milpa-worker.sh
@@ -38,7 +38,7 @@ chmod 755 milpa-installer-latest
 ./milpa-installer-latest
 
 pip install yq
-yq -y ".clusterName=\"${cluster_name}\" | .cloud.aws.accessKeyID=\"${aws_access_key_id}\" | .cloud.aws.secretAccessKey=\"${aws_secret_access_key}\" | .cloud.aws.vpcID=\"\" | .nodes.itzo.url=\"${itzo_url}\" | .nodes.itzo.version=\"${itzo_version}\" | .nodes.extraSecurityGroups=${extra_security_groups} | .license.key=\"${license_key}\" | .license.id=\"${license_id}\" | .license.username=\"${license_username}\" | .license.password=\"${license_password}\"" /opt/milpa/etc/server.yml > /opt/milpa/etc/server.yml.new && mv /opt/milpa/etc/server.yml.new /opt/milpa/etc/server.yml
+yq -y ".clusterName=\"${cluster_name}\" | .cloud.aws.accessKeyID=\"${aws_access_key_id}\" | .cloud.aws.secretAccessKey=\"${aws_secret_access_key}\" | .cloud.aws.vpcID=\"\" | .nodes.itzo.url=\"${itzo_url}\" | .nodes.itzo.version=\"${itzo_version}\" | .nodes.extraCIDRs=[\"${pod_cidr}\"] | .license.key=\"${license_key}\" | .license.id=\"${license_id}\" | .license.username=\"${license_username}\" | .license.password=\"${license_password}\"" /opt/milpa/etc/server.yml > /opt/milpa/etc/server.yml.new && mv /opt/milpa/etc/server.yml.new /opt/milpa/etc/server.yml
 sed -i 's#--milpa-endpoint 127.0.0.1:54555$#--milpa-endpoint 127.0.0.1:54555 --service-cluster-ip-range ${service_cidr} --kubeconfig /etc/kubernetes/kubelet.conf#' /etc/systemd/system/kiyot.service
 sed -i 's#--config /opt/milpa/etc/server.yml$#--config /opt/milpa/etc/server.yml --delete-cluster-lock-file#' /etc/systemd/system/milpa.service
 mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/milpa-worker.sh
+++ b/milpa-worker.sh
@@ -65,6 +65,7 @@ EOF
 systemctl daemon-reload
 systemctl restart criproxy
 
+# Configure kubelet.
 name=""
 while [[ -z "$name" ]]; do
     sleep 1

--- a/milpa-worker.sh
+++ b/milpa-worker.sh
@@ -5,7 +5,65 @@ cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -y kubelet=${k8s_version} kubeadm=${k8s_version} kubectl=${k8s_version} kubernetes-cni docker.io python-pip jq
+apt-get install -y kubelet=${k8s_version} kubeadm=${k8s_version} kubectl=${k8s_version} kubernetes-cni containerd python-pip jq
+
+# Configure containerd. This assumes kubenet is used for networking.
+modprobe br_netfilter
+sysctl net.bridge.bridge-nf-call-iptables=1; echo "net.bridge.bridge-nf-call-iptables=1" >> /etc/sysctl.conf
+sysctl net.ipv4.ip_forward=1; echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf
+mkdir -p /etc/cni/net.d
+mkdir -p /etc/containerd
+cat <<EOF > /etc/containerd/config.toml
+[plugins.cri]
+  [plugins.cri.cni]
+    conf_template = "/etc/containerd/cni-template.json"
+EOF
+cat <<EOF > /etc/containerd/cni-template.json
+{
+  "cniVersion": "0.3.1",
+  "name": "containerd-net",
+  "plugins": [
+    {
+      "type": "bridge",
+      "bridge": "cni0",
+      "isGateway": true,
+      "ipMasq": true,
+      "promiscMode": true,
+      "ipam": {
+        "type": "host-local",
+        "subnet": "{{.PodCIDR}}",
+        "routes": [
+          { "dst": "0.0.0.0/0" }
+        ]
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true}
+    }
+  ]
+}
+EOF
+systemctl restart containerd
+
+# Install criproxy.
+curl -L https://milpa-builds.s3.amazonaws.com/criproxy > /usr/local/bin/criproxy; chmod 755 /usr/local/bin/criproxy
+cat <<EOF > /etc/systemd/system/criproxy.service
+[Unit]
+Description=CRI Proxy
+Wants=containerd.service
+
+[Service]
+ExecStart=/usr/local/bin/criproxy -v 3 -logtostderr -connect /run/containerd/containerd.sock,kiyot:/opt/milpa/run/kiyot.sock -listen /run/criproxy.sock
+Restart=always
+StartLimitInterval=0
+RestartSec=10
+
+[Install]
+WantedBy=kubelet.service
+EOF
+systemctl daemon-reload
+systemctl restart criproxy
 
 name=""
 while [[ -z "$name" ]]; do
@@ -23,35 +81,33 @@ discovery:
     apiServerEndpoint: ${masterIP}:6443
 nodeRegistration:
   name: $name
-#  criSocket: unix:///opt/milpa/run/kiyot.sock
+  criSocket: unix:///run/criproxy.sock
   kubeletExtraArgs:
     cloud-provider: aws
+    network-plugin: kubenet
+    non-masquerade-cidr: 0.0.0.0/0
     max-pods: "1000"
     node-labels: kubernetes.io/role=milpa-worker
 EOF
 
+# Install milpa and kiyot.
 curl -L ${milpa_installer_url} > milpa-installer-latest
 chmod 755 milpa-installer-latest
 ./milpa-installer-latest
 
+# Configure milpa and kiyot.
 pip install yq
 yq -y ".clusterName=\"${cluster_name}\" | .cloud.aws.accessKeyID=\"${aws_access_key_id}\" | .cloud.aws.secretAccessKey=\"${aws_secret_access_key}\" | .cloud.aws.vpcID=\"\" | .nodes.itzo.url=\"${itzo_url}\" | .nodes.itzo.version=\"${itzo_version}\" | .nodes.extraCIDRs=[\"${pod_cidr}\"] | .license.key=\"${license_key}\" | .license.id=\"${license_id}\" | .license.username=\"${license_username}\" | .license.password=\"${license_password}\"" /opt/milpa/etc/server.yml > /opt/milpa/etc/server.yml.new && mv /opt/milpa/etc/server.yml.new /opt/milpa/etc/server.yml
 sed -i 's#--milpa-endpoint 127.0.0.1:54555$#--milpa-endpoint 127.0.0.1:54555 --service-cluster-ip-range ${service_cidr} --kubeconfig /etc/kubernetes/kubelet.conf#' /etc/systemd/system/kiyot.service
 sed -i 's#--config /opt/milpa/etc/server.yml$#--config /opt/milpa/etc/server.yml --delete-cluster-lock-file#' /etc/systemd/system/milpa.service
+
+# Ensure systemd will keep restarting kubelet.
 mkdir -p /etc/systemd/system/kubelet.service.d/
 echo -e "[Service]\nStartLimitInterval=0\nStartLimitIntervalSec=0\nRestart=always\nRestartSec=5" > /etc/systemd/system/kubelet.service.d/override.conf
 
 for i in {1..50}; do kubeadm join --config=/tmp/kubeadm-config.yaml && break || sleep 15; done
 
-# TODO: have kiyot retry creating k8s client and connect to the API server, and
-# have kubeadm configure the CRI. Then we can override all the extra parameters
-# via kubeletExtraArgs, and don't need to update kubeadm-flags.env here.
-echo "KUBELET_KUBEADM_ARGS=--cloud-provider=aws --hostname-override=$(hostname -f) --cgroup-driver=cgroupfs --pod-infra-container-image=k8s.gcr.io/pause:3.1 --container-runtime=remote --container-runtime-endpoint=unix:///opt/milpa/run/kiyot.sock --max-pods=1000" > /var/lib/kubelet/kubeadm-flags.env
-
 systemctl daemon-reload
 systemctl restart milpa
 systemctl restart kiyot
 systemctl restart kubelet
-
-docker ps -aq --no-trunc | xargs docker stop
-docker ps -aq --no-trunc | xargs docker rm

--- a/milpa-worker.sh
+++ b/milpa-worker.sh
@@ -5,7 +5,7 @@ cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -y kubelet kubeadm kubectl kubernetes-cni python python-pip jq docker.io
+apt-get install -y kubelet=${k8s_version} kubeadm=${k8s_version} kubectl=${k8s_version} kubernetes-cni docker.io
 
 name=""
 while [[ -z "$name" ]]; do

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,10 +27,10 @@ output "master_ip" {
   value = "${aws_instance.k8s-master.public_ip}"
 }
 
-output "milpa_worker_ip" {
-  value = "${aws_instance.k8s-milpa-worker.public_ip}"
+output "milpa_worker_ips" {
+  value = "${aws_instance.k8s-milpa-worker.*.public_ip}"
 }
 
-output "worker_ip" {
-  value = "${aws_instance.k8s-worker.public_ip}"
+output "worker_ips" {
+  value = "${aws_instance.k8s-worker.*.public_ip}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,6 +27,10 @@ output "master_ip" {
   value = "${aws_instance.k8s-master.public_ip}"
 }
 
+output "milpa_worker_ip" {
+  value = "${aws_instance.k8s-milpa-worker.public_ip}"
+}
+
 output "worker_ip" {
   value = "${aws_instance.k8s-worker.public_ip}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -23,6 +23,10 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 */
 
-output "master_dns" {
-  value = "${aws_instance.k8s-master.public_dns}"
+output "master_ip" {
+  value = "${aws_instance.k8s-master.public_ip}"
+}
+
+output "worker_ip" {
+  value = "${aws_instance.k8s-worker.public_ip}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -42,13 +42,13 @@ variable "license-username" {}
 variable "license-password" {}
 
 variable "region" {
-    default = "us-east-1"
+  default = "us-east-1"
 }
 
 variable "master-userdata" {
-    default = "master.sh"
+  default = "master.sh"
 }
 
 variable "worker-userdata" {
-    default = "worker.sh"
+  default = "worker.sh"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -91,3 +91,11 @@ variable "pod-cidr" {
 variable "service-cidr" {
   default = "10.96.0.0/12"
 }
+
+variable "workers" {
+  default = 0
+}
+
+variable "milpa-workers" {
+  default = 1
+}

--- a/variables.tf
+++ b/variables.tf
@@ -73,3 +73,23 @@ variable "master-userdata" {
 variable "worker-userdata" {
   default = "worker.sh"
 }
+
+variable "milpa-worker-userdata" {
+  default = "milpa-worker.sh"
+}
+
+variable "vpc-cidr" {
+  default = "10.0.0.0/16"
+}
+
+variable "subnet-cidr" {
+  default = "10.0.100.0/24"
+}
+
+variable "pod-cidr" {
+  default = "172.20.0.0/16"
+}
+
+variable "service-cidr" {
+  default = "10.96.0.0/12"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -91,8 +91,3 @@ variable "pod-cidr" {
 variable "service-cidr" {
   default = "10.96.0.0/12"
 }
-
-variable "non-masquerade-cidr" {
-  // If empty, pod-cidr will be used.
-  default = ""
-}

--- a/variables.tf
+++ b/variables.tf
@@ -25,18 +25,24 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 
 variable "k8stoken" {}
 
-variable "access_key" {
-  default = ""
-}
+variable "ssh-key-name" {}
 
-variable "secret_key" {
-  default = ""
-}
+variable "cluster-name" {}
 
-variable "k8s-ssh-key" {}
+variable "aws-access-key-id" {}
+
+variable "aws-secret-access-key" {}
+
+variable "license-key" {}
+
+variable "license-id" {}
+
+variable "license-username" {}
+
+variable "license-password" {}
 
 variable "region" {
-  default = "us-east-1"
+    default = "us-east-1"
 }
 
 variable "master-userdata" {

--- a/variables.tf
+++ b/variables.tf
@@ -91,3 +91,8 @@ variable "pod-cidr" {
 variable "service-cidr" {
   default = "10.96.0.0/12"
 }
+
+variable "non-masquerade-cidr" {
+  // If empty, pod-cidr will be used.
+  default = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,21 @@ variable "aws-secret-access-key" {
   default = ""
 }
 
+variable "milpa-installer-url" {
+  // The URL to download the Milpa installer from.
+  default = "https://download.elotl.co/milpa-installer-latest"
+}
+
+variable "itzo-url" {
+  // The URL to download the node agent from.
+  default = "http://itzo-download.s3.amazonaws.com"
+}
+
+variable "itzo-version" {
+  // The version of node agent to use.
+  default = "latest"
+}
+
 variable "license-key" {}
 
 variable "license-id" {}

--- a/variables.tf
+++ b/variables.tf
@@ -89,10 +89,12 @@ variable "service-cidr" {
 }
 
 variable "workers" {
+  // Number of regular kubelet workers to create in the cluster.
   default = 0
 }
 
 variable "milpa-workers" {
+  // Number of Milpa workers to create in the cluster.
   default = 1
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -29,9 +29,15 @@ variable "ssh-key-name" {}
 
 variable "cluster-name" {}
 
-variable "aws-access-key-id" {}
+variable "aws-access-key-id" {
+  // If empty, IAM will be used.
+  default = ""
+}
 
-variable "aws-secret-access-key" {}
+variable "aws-secret-access-key" {
+  // If empty, IAM will be used.
+  default = ""
+}
 
 variable "license-key" {}
 

--- a/variables.tf
+++ b/variables.tf
@@ -103,3 +103,10 @@ variable "number-of-subnets" {
   // created in a random subnet.
   default = 3
 }
+
+variable "k8s-version" {
+  // You can specify a specific version, for example "1.13.5*", or "*" for
+  // using the latest version available. Don't forget the last asterisk, since
+  // packages are named 1.13.5-00, 1.14.0-00, etc.
+  default = "*"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -80,10 +80,6 @@ variable "vpc-cidr" {
   default = "10.0.0.0/16"
 }
 
-variable "subnet-cidr" {
-  default = "10.0.100.0/24"
-}
-
 variable "pod-cidr" {
   default = "172.20.0.0/16"
 }
@@ -98,4 +94,10 @@ variable "workers" {
 
 variable "milpa-workers" {
   default = 1
+}
+
+variable "number-of-subnets" {
+  // Number of subnets to create in the VPC. Workers and Milpa pods will be
+  // created in a random subnet.
+  default = 3
 }

--- a/variables.tf
+++ b/variables.tf
@@ -23,8 +23,6 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 */
 
-variable "k8stoken" {}
-
 variable "ssh-key-name" {}
 
 variable "cluster-name" {}

--- a/worker.sh
+++ b/worker.sh
@@ -44,7 +44,7 @@ echo -e "[Service]\nStartLimitInterval=0\nStartLimitIntervalSec=0\nRestart=alway
 
 for i in {1..50}; do kubeadm join --config=/tmp/kubeadm-config.yaml && break || sleep 15; done
 
-echo "KUBELET_KUBEADM_ARGS=--cloud-provider=aws --cgroup-driver=cgroupfs --pod-infra-container-image=k8s.gcr.io/pause:3.1 --container-runtime=remote --container-runtime-endpoint=/opt/milpa/run/kiyot.sock --max-pods=1000" > /var/lib/kubelet/kubeadm-flags.env
+echo "KUBELET_KUBEADM_ARGS=--cloud-provider=aws --hostname-override=$(hostname -f) --cgroup-driver=cgroupfs --pod-infra-container-image=k8s.gcr.io/pause:3.1 --container-runtime=remote --container-runtime-endpoint=/opt/milpa/run/kiyot.sock --max-pods=1000" > /var/lib/kubelet/kubeadm-flags.env
 
 systemctl daemon-reload
 systemctl restart milpa

--- a/worker.sh
+++ b/worker.sh
@@ -27,6 +27,7 @@ nodeRegistration:
     cloud-provider: aws
     network-plugin: kubenet
     non-masquerade-cidr: 0.0.0.0/0
+    node-labels: kubernetes.io/role=worker
 EOF
 
 modprobe br_netfilter

--- a/worker.sh
+++ b/worker.sh
@@ -7,11 +7,6 @@ EOF
 apt-get update
 apt-get install -y kubelet kubeadm kubectl kubernetes-cni docker.io
 
-non_masquerade_cidr="${non_masquerade_cidr}"
-if [[ -z "$non_masquerade_cidr" ]]; then
-    non_masquerade_cidr="${pod_cidr}"
-fi
-
 name=""
 while [[ -z "$name" ]]; do
     sleep 1
@@ -31,7 +26,7 @@ nodeRegistration:
   kubeletExtraArgs:
     cloud-provider: aws
     network-plugin: kubenet
-    non-masquerade-cidr: $non_masquerade_cidr
+    non-masquerade-cidr: 0.0.0.0/0
 EOF
 
 modprobe br_netfilter

--- a/worker.sh
+++ b/worker.sh
@@ -31,12 +31,12 @@ modprobe br_netfilter
 sysctl net.bridge.bridge-nf-call-iptables=1
 sysctl net.ipv4.ip_forward=1
 
-wget https://download.elotl.co/milpa-installer-latest
+curl -L ${milpa_installer_url} > milpa-installer-latest
 chmod 755 milpa-installer-latest
 ./milpa-installer-latest
 
 pip install yq
-yq -y ".clusterName=\"${cluster_name}\" | .cloud.aws.accessKeyID=\"${aws_access_key_id}\" | .cloud.aws.secretAccessKey=\"${aws_secret_access_key}\" | .cloud.aws.vpcID=\"\" | .license.key=\"${license_key}\" | .license.id=\"${license_id}\" | .license.username=\"${license_username}\" | .license.password=\"${license_password}\"" /opt/milpa/etc/server.yml > /opt/milpa/etc/server.yml.new && mv /opt/milpa/etc/server.yml.new /opt/milpa/etc/server.yml
+yq -y ".clusterName=\"${cluster_name}\" | .cloud.aws.accessKeyID=\"${aws_access_key_id}\" | .cloud.aws.secretAccessKey=\"${aws_secret_access_key}\" | .cloud.aws.vpcID=\"\" | .nodes.itzo.url=\"${itzo_url}\" | .nodes.itzo.version=\"${itzo_version}\" | .license.key=\"${license_key}\" | .license.id=\"${license_id}\" | .license.username=\"${license_username}\" | .license.password=\"${license_password}\"" /opt/milpa/etc/server.yml > /opt/milpa/etc/server.yml.new && mv /opt/milpa/etc/server.yml.new /opt/milpa/etc/server.yml
 sed -i 's#--milpa-endpoint 127.0.0.1:54555$#--milpa-endpoint 127.0.0.1:54555 --non-masquerade-cidr 10.96.0.0/12 --kubeconfig /etc/kubernetes/kubelet.conf#' /etc/systemd/system/kiyot.service
 sed -i 's#--config /opt/milpa/etc/server.yml$#--config /opt/milpa/etc/server.yml --delete-cluster-lock-file#' /etc/systemd/system/milpa.service
 mkdir -p /etc/systemd/system/kubelet.service.d/

--- a/worker.sh
+++ b/worker.sh
@@ -5,8 +5,33 @@ cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -y kubelet kubeadm kubectl kubernetes-cni
+apt-get install -y kubelet kubeadm kubectl kubernetes-cni python python-pip jq
+
+# Install docker so kubeadm won't complain.
 curl -sSL https://get.docker.com/ | sh
 systemctl start docker
 
-for i in {1..50}; do kubeadm join --token=${k8stoken} ${masterIP} && break || sleep 15; done
+modprobe br_netfilter
+sysctl net.bridge.bridge-nf-call-iptables=1
+sysctl net.ipv4.ip_forward=1
+
+wget https://download.elotl.co/milpa-installer-latest
+chmod 755 milpa-installer-latest
+./milpa-installer-latest
+
+pip install yq
+yq -y ".clusterName=\"${cluster_name}\" | .cloud.aws.accessKeyID=\"${aws_access_key_id}\" | .cloud.aws.secretAccessKey=\"${aws_secret_access_key}\" | .cloud.aws.vpcID=\"\" | .license.key=\"${license_key}\" | .license.id=\"${license_id}\" | .license.username=\"${license_username}\" | .license.password=\"${license_password}\"" /opt/milpa/etc/server.yml > /opt/milpa/etc/server.yml.new && mv /opt/milpa/etc/server.yml.new /opt/milpa/etc/server.yml
+sed -i 's#--milpa-endpoint 127.0.0.1:54555$#--milpa-endpoint 127.0.0.1:54555 --non-masquerade-cidr 10.96.0.0/12 --kubeconfig /etc/kubernetes/kubelet.conf#' /etc/systemd/system/kiyot.service
+sed -i 's#--config /opt/milpa/etc/server.yml$#--config /opt/milpa/etc/server.yml --delete-cluster-lock-file#' /etc/systemd/system/milpa.service
+mkdir -p /etc/systemd/system/kubelet.service.d/
+echo -e "[Service]\nStartLimitInterval=0\nStartLimitIntervalSec=0\nRestart=always\nRestartSec=5" > /etc/systemd/system/kubelet.service.d/override.conf
+
+for i in {1..50}; do kubeadm join --discovery-token-unsafe-skip-ca-verification --token=${k8stoken} ${masterIP}:6443 && break || sleep 15; done
+
+echo 'KUBELET_KUBEADM_ARGS=--cgroup-driver=cgroupfs --pod-infra-container-image=k8s.gcr.io/pause:3.1 --container-runtime=remote --container-runtime-endpoint=/opt/milpa/run/kiyot.sock --max-pods=1000' > /var/lib/kubelet/kubeadm-flags.env
+
+systemctl daemon-reload
+systemctl restart milpa; sleep 30; systemctl restart kiyot
+
+docker ps -aq --no-trunc | xargs docker stop
+docker ps -aq --no-trunc | xargs docker rm

--- a/worker.sh
+++ b/worker.sh
@@ -37,7 +37,7 @@ chmod 755 milpa-installer-latest
 
 pip install yq
 yq -y ".clusterName=\"${cluster_name}\" | .cloud.aws.accessKeyID=\"${aws_access_key_id}\" | .cloud.aws.secretAccessKey=\"${aws_secret_access_key}\" | .cloud.aws.vpcID=\"\" | .nodes.itzo.url=\"${itzo_url}\" | .nodes.itzo.version=\"${itzo_version}\" | .license.key=\"${license_key}\" | .license.id=\"${license_id}\" | .license.username=\"${license_username}\" | .license.password=\"${license_password}\"" /opt/milpa/etc/server.yml > /opt/milpa/etc/server.yml.new && mv /opt/milpa/etc/server.yml.new /opt/milpa/etc/server.yml
-sed -i 's#--milpa-endpoint 127.0.0.1:54555$#--milpa-endpoint 127.0.0.1:54555 --non-masquerade-cidr 10.96.0.0/12 --kubeconfig /etc/kubernetes/kubelet.conf#' /etc/systemd/system/kiyot.service
+sed -i 's#--milpa-endpoint 127.0.0.1:54555$#--milpa-endpoint 127.0.0.1:54555 --service-cluster-ip-range 10.96.0.0/12 --kubeconfig /etc/kubernetes/kubelet.conf#' /etc/systemd/system/kiyot.service
 sed -i 's#--config /opt/milpa/etc/server.yml$#--config /opt/milpa/etc/server.yml --delete-cluster-lock-file#' /etc/systemd/system/milpa.service
 mkdir -p /etc/systemd/system/kubelet.service.d/
 echo -e "[Service]\nStartLimitInterval=0\nStartLimitIntervalSec=0\nRestart=always\nRestartSec=5" > /etc/systemd/system/kubelet.service.d/override.conf

--- a/worker.sh
+++ b/worker.sh
@@ -5,7 +5,7 @@ cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -y kubelet=${k8s_version} kubeadm=${k8s_version} kubectl=${k8s_version} kubernetes-cni docker.io
+apt-get install -y kubelet=${k8s_version} kubeadm=${k8s_version} kubectl=${k8s_version} kubernetes-cni docker.io python-pip jq
 
 # Docker sets the policy for the FORWARD chain to DROP, change it back.
 iptables -P FORWARD ACCEPT

--- a/worker.sh
+++ b/worker.sh
@@ -7,6 +7,10 @@ EOF
 apt-get update
 apt-get install -y kubelet kubeadm kubectl kubernetes-cni docker.io
 
+if [[ -z "${non_masquerade_cidr}" ]]; then
+    non_masquerade_cidr="${pod_cidr}"
+fi
+
 cat <<EOF > /tmp/kubeadm-config.yaml
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: JoinConfiguration
@@ -20,7 +24,7 @@ nodeRegistration:
   kubeletExtraArgs:
     cloud-provider: aws
     network-plugin: kubenet
-    non-masquerade-cidr: ${pod_cidr}
+    non-masquerade-cidr: ${non_masquerade_cidr}
 EOF
 
 modprobe br_netfilter

--- a/worker.sh
+++ b/worker.sh
@@ -31,7 +31,9 @@ for i in {1..50}; do kubeadm join --discovery-token-unsafe-skip-ca-verification 
 echo 'KUBELET_KUBEADM_ARGS=--cgroup-driver=cgroupfs --pod-infra-container-image=k8s.gcr.io/pause:3.1 --container-runtime=remote --container-runtime-endpoint=/opt/milpa/run/kiyot.sock --max-pods=1000' > /var/lib/kubelet/kubeadm-flags.env
 
 systemctl daemon-reload
-systemctl restart milpa; sleep 30; systemctl restart kiyot
+systemctl restart milpa
+systemctl restart kiyot
+systemctl restart kubelet
 
 docker ps -aq --no-trunc | xargs docker stop
 docker ps -aq --no-trunc | xargs docker rm

--- a/worker.sh
+++ b/worker.sh
@@ -26,9 +26,9 @@ sed -i 's#--config /opt/milpa/etc/server.yml$#--config /opt/milpa/etc/server.yml
 mkdir -p /etc/systemd/system/kubelet.service.d/
 echo -e "[Service]\nStartLimitInterval=0\nStartLimitIntervalSec=0\nRestart=always\nRestartSec=5" > /etc/systemd/system/kubelet.service.d/override.conf
 
-for i in {1..50}; do kubeadm join --discovery-token-unsafe-skip-ca-verification --token=${k8stoken} ${masterIP}:6443 && break || sleep 15; done
+for i in {1..50}; do kubeadm join --discovery-token-unsafe-skip-ca-verification --token=${k8stoken} ${masterIP}:6443 --node-name=$(hostname -f) && break || sleep 15; done
 
-echo 'KUBELET_KUBEADM_ARGS=--cgroup-driver=cgroupfs --pod-infra-container-image=k8s.gcr.io/pause:3.1 --container-runtime=remote --container-runtime-endpoint=/opt/milpa/run/kiyot.sock --max-pods=1000' > /var/lib/kubelet/kubeadm-flags.env
+echo "KUBELET_KUBEADM_ARGS=--cloud-provider=aws --cgroup-driver=cgroupfs --pod-infra-container-image=k8s.gcr.io/pause:3.1 --container-runtime=remote --container-runtime-endpoint=/opt/milpa/run/kiyot.sock --max-pods=1000" > /var/lib/kubelet/kubeadm-flags.env
 
 systemctl daemon-reload
 systemctl restart milpa

--- a/worker.sh
+++ b/worker.sh
@@ -11,6 +11,12 @@ if [[ -z "${non_masquerade_cidr}" ]]; then
     non_masquerade_cidr="${pod_cidr}"
 fi
 
+name=""
+while [[ -z "$name" ]]; do
+    sleep 1
+    name="$(hostname -f)"
+done
+
 cat <<EOF > /tmp/kubeadm-config.yaml
 apiVersion: kubeadm.k8s.io/v1beta1
 kind: JoinConfiguration
@@ -20,7 +26,7 @@ discovery:
     unsafeSkipCAVerification: true
     apiServerEndpoint: ${masterIP}:6443
 nodeRegistration:
-  name: $(hostname -f)
+  name: $name
   kubeletExtraArgs:
     cloud-provider: aws
     network-plugin: kubenet

--- a/worker.sh
+++ b/worker.sh
@@ -7,6 +7,9 @@ EOF
 apt-get update
 apt-get install -y kubelet kubeadm kubectl kubernetes-cni docker.io
 
+# Docker sets the policy for the FORWARD chain to DROP, change it back.
+iptables -P FORWARD ACCEPT
+
 name=""
 while [[ -z "$name" ]]; do
     sleep 1
@@ -29,10 +32,5 @@ nodeRegistration:
     non-masquerade-cidr: 0.0.0.0/0
     node-labels: kubernetes.io/role=worker
 EOF
-
-modprobe br_netfilter
-sysctl net.bridge.bridge-nf-call-iptables=1
-sysctl net.ipv4.ip_forward=1
-iptables -P FORWARD ACCEPT
 
 for i in {1..50}; do kubeadm join --config=/tmp/kubeadm-config.yaml && break || sleep 15; done

--- a/worker.sh
+++ b/worker.sh
@@ -5,7 +5,7 @@ cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -y kubelet kubeadm kubectl kubernetes-cni docker.io
+apt-get install -y kubelet=${k8s_version} kubeadm=${k8s_version} kubectl=${k8s_version} kubernetes-cni docker.io
 
 # Docker sets the policy for the FORWARD chain to DROP, change it back.
 iptables -P FORWARD ACCEPT

--- a/worker.sh
+++ b/worker.sh
@@ -7,7 +7,8 @@ EOF
 apt-get update
 apt-get install -y kubelet kubeadm kubectl kubernetes-cni docker.io
 
-if [[ -z "${non_masquerade_cidr}" ]]; then
+non_masquerade_cidr="${non_masquerade_cidr}"
+if [[ -z "$non_masquerade_cidr" ]]; then
     non_masquerade_cidr="${pod_cidr}"
 fi
 
@@ -30,7 +31,7 @@ nodeRegistration:
   kubeletExtraArgs:
     cloud-provider: aws
     network-plugin: kubenet
-    non-masquerade-cidr: ${non_masquerade_cidr}
+    non-masquerade-cidr: $non_masquerade_cidr
 EOF
 
 modprobe br_netfilter

--- a/worker.sh
+++ b/worker.sh
@@ -5,7 +5,7 @@ cat <<EOF > /etc/apt/sources.list.d/kubernetes.list
 deb http://apt.kubernetes.io/ kubernetes-xenial main
 EOF
 apt-get update
-apt-get install -y kubelet kubeadm kubectl kubernetes-cni python python-pip jq
+apt-get install -y kubelet kubeadm kubectl kubernetes-cni docker.io
 
 cat <<EOF > /tmp/kubeadm-config.yaml
 apiVersion: kubeadm.k8s.io/v1beta1
@@ -17,39 +17,15 @@ discovery:
     apiServerEndpoint: ${masterIP}:6443
 nodeRegistration:
   name: $(hostname -f)
-#  criSocket: /opt/milpa/run/kiyot.sock
   kubeletExtraArgs:
     cloud-provider: aws
-    max-pods: "1000"
+    network-plugin: kubenet
+    non-masquerade-cidr: ${pod_cidr}
 EOF
-
-# Install docker so kubeadm won't complain.
-curl -sSL https://get.docker.com/ | sh
-systemctl start docker
 
 modprobe br_netfilter
 sysctl net.bridge.bridge-nf-call-iptables=1
 sysctl net.ipv4.ip_forward=1
-
-curl -L ${milpa_installer_url} > milpa-installer-latest
-chmod 755 milpa-installer-latest
-./milpa-installer-latest
-
-pip install yq
-yq -y ".clusterName=\"${cluster_name}\" | .cloud.aws.accessKeyID=\"${aws_access_key_id}\" | .cloud.aws.secretAccessKey=\"${aws_secret_access_key}\" | .cloud.aws.vpcID=\"\" | .nodes.itzo.url=\"${itzo_url}\" | .nodes.itzo.version=\"${itzo_version}\" | .license.key=\"${license_key}\" | .license.id=\"${license_id}\" | .license.username=\"${license_username}\" | .license.password=\"${license_password}\"" /opt/milpa/etc/server.yml > /opt/milpa/etc/server.yml.new && mv /opt/milpa/etc/server.yml.new /opt/milpa/etc/server.yml
-sed -i 's#--milpa-endpoint 127.0.0.1:54555$#--milpa-endpoint 127.0.0.1:54555 --service-cluster-ip-range 10.96.0.0/12 --kubeconfig /etc/kubernetes/kubelet.conf#' /etc/systemd/system/kiyot.service
-sed -i 's#--config /opt/milpa/etc/server.yml$#--config /opt/milpa/etc/server.yml --delete-cluster-lock-file#' /etc/systemd/system/milpa.service
-mkdir -p /etc/systemd/system/kubelet.service.d/
-echo -e "[Service]\nStartLimitInterval=0\nStartLimitIntervalSec=0\nRestart=always\nRestartSec=5" > /etc/systemd/system/kubelet.service.d/override.conf
+iptables -P FORWARD ACCEPT
 
 for i in {1..50}; do kubeadm join --config=/tmp/kubeadm-config.yaml && break || sleep 15; done
-
-echo "KUBELET_KUBEADM_ARGS=--cloud-provider=aws --hostname-override=$(hostname -f) --cgroup-driver=cgroupfs --pod-infra-container-image=k8s.gcr.io/pause:3.1 --container-runtime=remote --container-runtime-endpoint=/opt/milpa/run/kiyot.sock --max-pods=1000" > /var/lib/kubelet/kubeadm-flags.env
-
-systemctl daemon-reload
-systemctl restart milpa
-systemctl restart kiyot
-systemctl restart kubelet
-
-docker ps -aq --no-trunc | xargs docker stop
-docker ps -aq --no-trunc | xargs docker rm


### PR DESCRIPTION
The main change here is to install criproxy, which will create pods/containers etc via containerd on milpa workers, and only use kiyot/milpa if a pod is annotated with `"kubernetes.io/target-runtime":"kiyot"`.